### PR TITLE
fix(models): a grid-run kind's name never reaches a model label

### DIFF
--- a/lib/features/network/logic/model_usage.dart
+++ b/lib/features/network/logic/model_usage.dart
@@ -120,9 +120,13 @@ int modelNodeCount(Iterable<OverviewNode> nodes, String modelId) {
 /// A short id splits into head alone: pinning a tail on a name that was never
 /// going to be shortened only invites a break in the middle of a word.
 ({String org, String head, String tail}) splitModelId(String id) {
-  final slash = id.indexOf('/');
-  final org = slash < 0 ? '' : id.substring(0, slash + 1);
-  final rest = id.substring(org.length);
+  // Stripped before the split, not after: the prefix would otherwise become the
+  // `org` — `openrouter:deepseek/` — and print the supplier at the front of
+  // every row in the column that repeats most. See [withoutGridRunPrefix].
+  final stripped = withoutGridRunPrefix(id);
+  final slash = stripped.indexOf('/');
+  final org = slash < 0 ? '' : stripped.substring(0, slash + 1);
+  final rest = stripped.substring(org.length);
   if (rest.length <= _minToShorten) return (org: org, head: rest, tail: '');
   final segments = rest.split('-');
   var tail = '';

--- a/lib/features/network/logic/node_display.dart
+++ b/lib/features/network/logic/node_display.dart
@@ -299,6 +299,42 @@ String? mediaCapabilityLabel(String id) => _capabilityLabels[id];
 /// empty, not "ready to chat". One constant so every empty-state check agrees.
 const String kAutoModelId = 'auto';
 
+/// The API-service kinds a grid stands up for its members rather than a person
+/// joining with their own credential — today just the one.
+///
+/// A member never chose these and holds no credential for them, so the kind's
+/// name is the name of a supplier they have no relationship with. It is stripped
+/// from every id the app *shows*; the id it *sends* is untouched.
+const Set<String> kGridRunKinds = {'openrouter'};
+
+/// A model id with a grid-run kind's `<kind>:` prefix taken off, for display
+/// only — `openrouter:deepseek/deepseek-v4-flash-0731` reads
+/// `deepseek/deepseek-v4-flash-0731`. Every other id comes back trimmed and
+/// otherwise whole, prefix and all: `claude:claude-opus-5` names a seat the user
+/// set up themselves.
+///
+/// **A backstop, not the fix.** The provider advertises these models bare, so on
+/// a grid whose provider has been through a release carrying that change there
+/// is no prefix here to remove. This catches the grids that registered before
+/// it, and only where the app controls the text — the client config the app
+/// hands a user to paste carries the wire id verbatim and cannot be rewritten by
+/// anything here.
+///
+/// Never used for matching: [modelKey] and every comparison stay on the raw id,
+/// so a display rule can't silently change which model a row is about.
+String withoutGridRunPrefix(String id) {
+  final trimmed = id.trim();
+  final colon = trimmed.indexOf(':');
+  if (colon <= 0) return trimmed;
+  if (!kGridRunKinds.contains(trimmed.substring(0, colon).toLowerCase())) {
+    return trimmed;
+  }
+  final rest = trimmed.substring(colon + 1).trim();
+  // A bare `openrouter:` names nothing; showing the id as it came beats showing
+  // an empty cell where a model should be.
+  return rest.isEmpty ? trimmed : rest;
+}
+
 /// One model id, in the form the app compares by.
 ///
 /// Ids reach the app from three directions that disagree on case and spacing:

--- a/lib/features/playground/logic/chat_message.dart
+++ b/lib/features/playground/logic/chat_message.dart
@@ -1,6 +1,7 @@
 import '../../../infrastructure/cli/agent_event.dart';
 import '../../../infrastructure/cli/agent_turn_part.dart';
 import '../../chat/logic/turn_model_share.dart';
+import '../../network/logic/node_display.dart' show withoutGridRunPrefix;
 import 'chat_context.dart';
 import 'chat_file.dart';
 import 'message_media.dart';
@@ -278,11 +279,15 @@ String _pad(int value) => value.toString().padLeft(2, '0');
 /// "claude" twice and read as a config string rather than as Opus. This gives
 /// `claude/opus-5`, and `codex-cli:gpt-5.6-terra` → `codex-cli/gpt-5.6-terra`.
 ///
+/// A grid-run kind loses its prefix outright rather than gaining a slash
+/// ([withoutGridRunPrefix]): nobody chose that kind, so naming it here would
+/// print a supplier the reader has no relationship with.
+///
 /// Display only — the id itself is what a request carries, so this never goes on
 /// the wire. Anything without a kind (a grid model, `auto`, the media modes)
 /// comes back trimmed and otherwise untouched.
 String modelDisplayLabel(String id) {
-  final trimmed = id.trim();
+  final trimmed = withoutGridRunPrefix(id);
   final colon = trimmed.indexOf(':');
   if (colon <= 0) return trimmed;
   final kind = trimmed.substring(0, colon);

--- a/lib/features/provider_node/logic/api_engine_catalog.dart
+++ b/lib/features/provider_node/logic/api_engine_catalog.dart
@@ -167,8 +167,16 @@ const String kClaudeSeatKind = 'claude';
 ///
 /// The CLI ships `openai` (a pasted API key, ADR 0012) and two **CLI seats** —
 /// `claude` and `codex-cli` — which serve a coding CLI already installed here.
-/// OpenRouter, Anthropic, Gemini, … are a one-line addition each when their kind
-/// is whitelisted.
+/// Anthropic, Gemini, … are a one-line addition each when their kind is
+/// whitelisted.
+///
+/// **`openrouter` is not one of them, and must not be added.** Nobody joins with
+/// that kind: the grid stands it up for a member on a credential the member
+/// never holds, so an entry here would offer a provider they cannot sign in to
+/// and name the supplier their grid buys from. The CLI now refuses `grid catalog
+/// --api openrouter` outright, so an entry added anyway would be dropped by the
+/// `result.ok` check below rather than shown — but it would still put the word
+/// in this file, and this comment is the reason it isn't here.
 ///
 /// The `codex` kind (a ChatGPT subscription signed in over OAuth, ADR 0015) is
 /// deliberately **not** here. It answers on `responses` only, so everything the

--- a/test/network/grid_run_model_id_test.dart
+++ b/test/network/grid_run_model_id_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:grid_app/features/network/logic/model_usage.dart';
+import 'package:grid_app/features/network/logic/node_display.dart';
+
+/// The kind a grid stands up for its members never reaches their eyes.
+///
+/// A member holds no credential for it and never chose it, so its name is the
+/// name of a supplier they have no relationship with and cannot act on. The
+/// provider advertises these models bare; this covers the grids that registered
+/// before that release, on the surfaces the app controls the text of.
+void main() {
+  group('withoutGridRunPrefix', () {
+    test('takes the grid-run kind off, leaving the model whole', () {
+      expect(
+        withoutGridRunPrefix('openrouter:deepseek/deepseek-v4-flash-0731'),
+        'deepseek/deepseek-v4-flash-0731',
+      );
+    });
+
+    test('leaves a kind a person joined themselves alone', () {
+      // Not a punctuation rule: `claude:` is a seat the user set up, and hiding
+      // it would hide what they configured.
+      expect(withoutGridRunPrefix('claude:claude-opus-5'), 'claude:claude-opus-5');
+      expect(withoutGridRunPrefix('codex-cli:gpt-5.6-terra'), 'codex-cli:gpt-5.6-terra');
+    });
+
+    test('leaves an id with no kind at all alone', () {
+      expect(withoutGridRunPrefix('qwen/qwen3.6-27b'), 'qwen/qwen3.6-27b');
+      expect(withoutGridRunPrefix('auto'), 'auto');
+      expect(withoutGridRunPrefix(':gpt-5.5'), ':gpt-5.5');
+    });
+
+    test('matches the kind however the relay cased it', () {
+      expect(withoutGridRunPrefix('OPENROUTER:qwen/qwen3.8-27b'), 'qwen/qwen3.8-27b');
+    });
+
+    test('a prefix with nothing behind it comes back whole, never empty', () {
+      // An empty cell where a model should be reads as a bug; the raw id at
+      // least names something.
+      expect(withoutGridRunPrefix('openrouter:'), 'openrouter:');
+      expect(withoutGridRunPrefix('openrouter:   '), 'openrouter:');
+    });
+
+    test('the list is the one place a kind is named', () {
+      expect(kGridRunKinds, {'openrouter'});
+    });
+  });
+
+  group('splitModelId', () {
+    test('strips before it splits, so the supplier never becomes the org', () {
+      // The org is the half that repeats down the whole column — the most
+      // visible place in the panel for a word nobody should be reading.
+      final parts = splitModelId('openrouter:deepseek/deepseek-v4-flash-0731');
+      expect(parts.org, 'deepseek/');
+      expect(parts.org + parts.head + parts.tail, 'deepseek/deepseek-v4-flash-0731');
+    });
+
+    test('an ordinary maker prefix is still the org', () {
+      final parts = splitModelId('qwen/qwen3.8-27b');
+      expect(parts.org, 'qwen/');
+      expect(parts.org + parts.head + parts.tail, 'qwen/qwen3.8-27b');
+    });
+
+    test('pins the distinguishing tail rather than the front', () {
+      final parts = splitModelId('NVIDIA-Nemotron-3.5-Lightning-3B-v2');
+      expect(parts.org, '');
+      expect(parts.tail.isNotEmpty, isTrue);
+      expect(parts.head + parts.tail, 'NVIDIA-Nemotron-3.5-Lightning-3B-v2');
+    });
+  });
+
+  group('the display rule never touches matching', () {
+    test('modelKey keeps the raw id, prefix and all', () {
+      // Ids are compared across three sources that disagree on case; letting a
+      // display rule into that comparison would make a row silently about a
+      // different model.
+      expect(
+        modelKey('openrouter:deepseek/deepseek-v4-flash-0731'),
+        'openrouter:deepseek/deepseek-v4-flash-0731',
+      );
+    });
+  });
+}

--- a/test/playground/model_short_label_test.dart
+++ b/test/playground/model_short_label_test.dart
@@ -60,4 +60,45 @@ void main() {
       expect(modelShortLabel('org/team/model-x'), 'model-x');
     });
   });
+
+  group('a grid-run kind', () {
+    // The grid stands these up itself, on a credential no member holds, so the
+    // kind's name is a supplier the reader has nothing to do with. The provider
+    // advertises them bare now; this is what covers a grid that registered
+    // before that release.
+    test('loses its prefix outright rather than gaining a slash', () {
+      expect(
+        modelDisplayLabel('openrouter:deepseek/deepseek-v4-flash-0731'),
+        'deepseek/deepseek-v4-flash-0731',
+      );
+      expect(modelDisplayLabel('openrouter:qwen/qwen3.8-27b'), 'qwen/qwen3.8-27b');
+    });
+
+    test('is stripped whatever case the relay lowercased it into', () {
+      expect(modelDisplayLabel('OpenRouter:qwen/qwen3.8-27b'), 'qwen/qwen3.8-27b');
+    });
+
+    test('shortens to the model name alone, naming nothing else', () {
+      expect(
+        modelShortLabel('openrouter:deepseek/deepseek-v4-flash-0731'),
+        'deepseek-v4-flash-0731',
+      );
+    });
+
+    test('a kind a person joined themselves keeps its prefix', () {
+      // The rule is about who chose the kind, not about the punctuation: a seat
+      // the user set up is theirs to see.
+      expect(modelDisplayLabel('claude:claude-opus-5'), 'claude/opus-5');
+      expect(modelDisplayLabel('openai:gpt-5.5'), 'openai/gpt-5.5');
+    });
+
+    test('a prefix with nothing after it comes back whole, not empty', () {
+      expect(modelDisplayLabel('openrouter:'), 'openrouter:');
+    });
+
+    test('an id that merely starts with the word is left alone', () {
+      // No colon, so no kind — this is a model somebody named, not a namespace.
+      expect(modelDisplayLabel('openrouter-mix/m1'), 'openrouter-mix/m1');
+    });
+  });
 }


### PR DESCRIPTION
## What

`withoutGridRunPrefix` strips a grid-run kind's `<kind>:` prefix from ids the app **shows**. Both display paths go through it: `modelDisplayLabel` (chat picker, reply footer, scheduled jobs) and `splitModelId`, which strips **before** it splits so the prefix cannot become the Models panel's `org` column.

## Why

`openrouter:deepseek/deepseek-v4-flash-0731` read as `openrouter/deepseek/deepseek-v4-flash-0731` in the picker and in the footer's hover line, and put `openrouter:deepseek/` in the column that repeats down every row. A member holds no credential for that kind and never chose it, so its name is a supplier they have nothing to do with.

A kind a person joined themselves keeps its prefix — `claude:claude-opus-5` is a seat they set up. `modelKey` and every comparison stay on the raw id, so a display rule can never quietly change which model a row is about.

## A backstop, not the fix

The provider now advertises these models bare (autonomous-grid#64), so a grid whose provider has been through that release has no prefix here to remove. This catches grids that registered before it, and only where the app owns the text — the client config the app hands a user to paste carries the wire id verbatim.

Also records why `openrouter` is not in `kApiProviders` and must not be added.

## Test plan

- [x] `flutter test` — 2990 tests; the only red one (`panel_controller_test.dart`) is a pre-existing load flake that passes when run alone
- [x] `flutter analyze` clean on every changed file
- [x] New `test/network/grid_run_model_id_test.dart` covers the strip, the kinds it must not touch, and that `modelKey` stays raw

`pubspec.lock` is deliberately not in this branch — it was already modified before this work.