### PR TITLE
Rebuild Share Intelligence as a route picked, then set up

### DIFF
--- a/lib/features/models/presentation/context_length_field.dart
+++ b/lib/features/models/presentation/context_length_field.dart
@@ -19,7 +19,6 @@ class ContextLengthField extends ConsumerWidget {
     required this.model,
     required this.value,
     required this.onChanged,
-    this.inline = false,
   });
 
   /// GGUF filename whose maximum context bounds the slider.
@@ -32,9 +31,6 @@ class ContextLengthField extends ConsumerWidget {
   /// Reports the picked context length (already snapped to 1k) as the user
   /// drags.
   final ValueChanged<int> onChanged;
-
-  /// See [ContextWindowField.inline].
-  final bool inline;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -53,7 +49,6 @@ class ContextLengthField extends ConsumerWidget {
               ? defaultContextLength(max)
               : value!.clamp(minContextTokens, max),
           onChanged: onChanged,
-          inline: inline,
         );
       },
     );

--- a/lib/features/models/presentation/serve_local_card.dart
+++ b/lib/features/models/presentation/serve_local_card.dart
@@ -8,6 +8,7 @@ import '../../../infrastructure/state/models/local_files.dart';
 import '../../../infrastructure/state/models/network_credential.dart';
 import '../../../shared/copy/plural.dart';
 import '../../../shared/theme/app_theme.dart';
+import '../../../shared/theme/share_page_theme.dart';
 import '../../../shared/widgets/advertise_as_field.dart';
 import '../../../shared/widgets/app_select_field.dart';
 import '../../../shared/widgets/app_spinner.dart';
@@ -362,10 +363,9 @@ class _ServeLocalCardState extends ConsumerState<ServeLocalCard> {
             // one button on the form that finishes the job.
             Align(
               alignment: Alignment.centerLeft,
-              child: TextButton.icon(
+              child: TextButton(
                 onPressed: () => showModelManager(context),
-                icon: const Icon(Icons.tune, size: 16),
-                label: const Text('Download or manage models'),
+                child: const Text('Download or manage models →'),
               ),
             ),
           ],
@@ -462,9 +462,7 @@ class _ServeActions extends StatelessWidget {
                 // What a first-time host actually wants to know before
                 // pressing it, which is that pressing it is not a commitment.
                 'You can stop at any time.',
-                style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                  color: AppPalette.textSecondary,
-                ),
+                style: ShareType.buttonHelper,
               ),
           ],
         ),

--- a/lib/features/models/presentation/serve_local_card.dart
+++ b/lib/features/models/presentation/serve_local_card.dart
@@ -380,9 +380,6 @@ class _ServeLocalCardState extends ConsumerState<ServeLocalCard> {
         ContextLengthField(
           model: selected.primary.name,
           value: _ctxSize,
-          // The slider's own box carries the number — see
-          // [ContextWindowField.inline].
-          inline: true,
           onChanged: (tokens) {
             setState(() => _ctxSize = tokens);
             // A machine still carrying a start-on-open record has to open with

--- a/lib/features/models/presentation/serve_local_card.dart
+++ b/lib/features/models/presentation/serve_local_card.dart
@@ -11,6 +11,7 @@ import '../../../shared/theme/app_theme.dart';
 import '../../../shared/widgets/advertise_as_field.dart';
 import '../../../shared/widgets/app_select_field.dart';
 import '../../../shared/widgets/app_spinner.dart';
+import '../../../shared/widgets/form_plate.dart';
 import '../../../shared/widgets/log_view.dart';
 import '../../../shared/widgets/node_name_field.dart';
 import '../../node_setup/logic/background_model_controller.dart';
@@ -128,11 +129,6 @@ class _ServeLocalCardState extends ConsumerState<ServeLocalCard> {
     ];
   }
 
-  /// Whether the pre-filled details are open for editing. Shut by default: the
-  /// summary above already says what they are, so opening is for changing them,
-  /// not for reading them.
-  bool _editingDetails = false;
-
   /// Keeps a start-on-open record in step with the form. No-ops unless one is
   /// armed *for this model*.
   ///
@@ -155,16 +151,6 @@ class _ServeLocalCardState extends ConsumerState<ServeLocalCard> {
 
   /// The name to announce [model] under: what the user typed, or the one
   /// derived from the filename when they left the field alone.
-  /// The window this model will actually start on — the typed value, or the
-  /// default read from the model's own ceiling. Null only while that ceiling is
-  /// still being read, where the summary simply leaves the clause out rather
-  /// than guessing a number the engine might not use.
-  int? _effectiveContext(String model) {
-    if (_ctxSize case final chosen?) return chosen;
-    final max = ref.watch(modelMaxContextProvider(model)).asData?.value;
-    return max == null ? null : defaultContextLength(max);
-  }
-
   String _advertiseName(String model) {
     final typed = _advertise.text.trim();
     return typed.isEmpty ? deriveAdvertiseName(model) : typed;
@@ -334,52 +320,67 @@ class _ServeLocalCardState extends ConsumerState<ServeLocalCard> {
         ),
       ];
 
+  /// The form, as one plate with its three questions ruled apart: which model,
+  /// what the grid calls it, and how much it remembers.
+  ///
+  /// All three are open. They spent a while behind a "Shared as … Change"
+  /// sentence, on the reasoning that they are defaults nobody edits — true, and
+  /// still the wrong shape: folded away they were *unverifiable*, and a form
+  /// whose one visible control is a dropdown gives the reader nothing to check
+  /// before they press a button that puts this machine on a network. Open, the
+  /// rules do the work the disclosure was doing.
   List<Widget> _serveControls(List<ModelGroup> groups, ModelGroup selected) => [
-    // AppSelectField, not DropdownButtonFormField: Material's popup can't be
-    // made to match the app's floating menus (square, edge-to-edge, no inset).
-    AppSelectField<String>(
-      label: 'Local model',
-      value: selected.primary.name,
-      options: [
-        for (final group in groups)
-          AppSelectOption(
-            value: group.primary.name,
-            label: group.displayName,
-            badges: _modelBadges(group),
+    FormPlate(
+      sections: [
+        Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            // AppSelectField, not DropdownButtonFormField: Material's popup
+            // can't be made to match the app's floating menus (square,
+            // edge-to-edge, no inset).
+            AppSelectField<String>(
+              label: 'Model',
+              value: selected.primary.name,
+              options: [
+                for (final group in groups)
+                  AppSelectOption(
+                    value: group.primary.name,
+                    label: group.displayName,
+                    badges: _modelBadges(group),
+                  ),
+              ],
+              // Reset the context choice so the slider falls back to the new
+              // model's own maximum instead of carrying over the previous one.
+              onChanged: (value) => setState(() {
+                _model = value;
+                _ctxSize = null;
+              }),
+            ),
+            const SizedBox(height: 6),
+            // Under the picker, where somebody who cannot find their model is
+            // already looking — not beside Start, where it competed with the
+            // one button on the form that finishes the job.
+            Align(
+              alignment: Alignment.centerLeft,
+              child: TextButton.icon(
+                onPressed: () => showModelManager(context),
+                icon: const Icon(Icons.tune, size: 16),
+                label: const Text('Download or manage models'),
+              ),
+            ),
+          ],
+        ),
+        FieldPair(
+          first: AdvertiseAsField(
+            controller: _advertise,
+            hintText: 'Qwen3.6-35B-A3B',
           ),
-      ],
-      // Reset the context choice so the slider falls back to the new
-      // model's own maximum instead of carrying over the previous one.
-      onChanged: (value) => setState(() {
-        _model = value;
-        _ctxSize = null;
-      }),
-    ),
-    const SizedBox(height: 10),
-    // Every one of these is pre-filled correctly from the model itself, so most
-    // starts never touch any of them. Folding them away was right and not
-    // enough: hidden, they were also *unverifiable* — you could not find out
-    // what name the grid would see without opening a section. A sentence says
-    // it in a line and still opens.
-    _DetailsSummary(
-      advertiseAs: _advertiseName(selected.primary.name),
-      nodeName: _nodeName.text.trim(),
-      contextTokens: _effectiveContext(selected.primary.name),
-      open: _editingDetails,
-      onToggle: () => setState(() => _editingDetails = !_editingDetails),
-    ),
-    if (_editingDetails) ...[
-      const SizedBox(height: 10),
-      _DetailsPanel(
-        names: [
-          AdvertiseAsField(controller: _advertise, hintText: 'Qwen3.6-35B-A3B'),
-          const SizedBox(height: 14),
-          NodeNameField(controller: _nodeName),
-        ],
-        window: ContextLengthField(
+          second: NodeNameField(controller: _nodeName),
+        ),
+        ContextLengthField(
           model: selected.primary.name,
           value: _ctxSize,
-          // The panel and the summary both carry the number already — see
+          // The slider's own box carries the number — see
           // [ContextWindowField.inline].
           inline: true,
           onChanged: (tokens) {
@@ -389,9 +390,9 @@ class _ServeLocalCardState extends ConsumerState<ServeLocalCard> {
             _refreshAutoServe(selected.primary.name);
           },
         ),
-      ),
-    ],
-    const SizedBox(height: 16),
+      ],
+    ),
+    const SizedBox(height: 18),
     _ServeActions(
       selected: selected,
       onStart: () => _start(selected.primary.name),
@@ -440,7 +441,7 @@ class _ServeActions extends StatelessWidget {
           const SizedBox(height: 12),
         ],
         Wrap(
-          spacing: 8,
+          spacing: 14,
           runSpacing: 8,
           crossAxisAlignment: WrapCrossAlignment.center,
           children: [
@@ -456,145 +457,18 @@ class _ServeActions extends StatelessWidget {
                 icon: const Icon(Icons.download_outlined, size: 18),
                 label: const Text('Finish downloading'),
               ),
-            TextButton.icon(
-              onPressed: onManage,
-              icon: const Icon(Icons.tune, size: 18),
-              label: const Text('Download or manage models'),
-            ),
+            if (selected.isComplete)
+              Text(
+                // What a first-time host actually wants to know before
+                // pressing it, which is that pressing it is not a commitment.
+                'You can stop at any time.',
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: AppPalette.textSecondary,
+                ),
+              ),
           ],
         ),
       ],
-    );
-  }
-}
-
-/// The three pre-filled details, as one sentence you can read or open.
-///
-/// This replaced a "Names and context window" expander, and the difference is
-/// not that it is shorter. A disclosure hides a *decision*; these are not
-/// decisions, they are defaults derived from the model and the machine, and the
-/// question a person actually has about a default is "what is it?" — which a
-/// closed expander is the one shape that cannot answer. Read it in a line,
-/// press Change only if it is wrong.
-///
-/// It also puts the weight back where it belongs. The model picker is the one
-/// real choice in this form; three full-width fields under it were drawn at
-/// exactly the same size, so nothing on the card looked more important than
-/// anything else.
-class _DetailsSummary extends StatelessWidget {
-  const _DetailsSummary({
-    required this.advertiseAs,
-    required this.nodeName,
-    required this.contextTokens,
-    required this.open,
-    required this.onToggle,
-  });
-
-  final String advertiseAs;
-  final String nodeName;
-
-  /// Null while the model's ceiling is still being read.
-  final int? contextTokens;
-
-  final bool open;
-  final VoidCallback onToggle;
-
-  /// Written as the grid will see it, not as the fields are labelled. "Model
-  /// name shown to the grid" is the right label above an input and the wrong
-  /// words in a sentence, where what matters is the name itself.
-  String get _sentence {
-    final from = nodeName.isEmpty ? 'this computer' : nodeName;
-    final window = contextTokens == null
-        ? ''
-        : ', remembering ${formatContextLength(contextTokens!)}';
-    return 'Shared as “$advertiseAs” from “$from”$window.';
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    AppTheme.watch(context);
-    final theme = Theme.of(context);
-    return Row(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Expanded(
-          child: Text(
-            _sentence,
-            style: theme.textTheme.bodySmall?.copyWith(
-              color: AppPalette.textSecondary,
-            ),
-          ),
-        ),
-        const SizedBox(width: 12),
-        // A text button, not a chevron: the row is a sentence, and a disclosure
-        // arrow on a sentence promises more words rather than the fields that
-        // actually open.
-        TextButton(
-          onPressed: onToggle,
-          style: TextButton.styleFrom(
-            padding: const EdgeInsets.symmetric(horizontal: 8),
-            minimumSize: const Size(0, 28),
-            tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-          ),
-          child: Text(open ? 'Done' : 'Change'),
-        ),
-      ],
-    );
-  }
-}
-
-/// The opened details, as one plate rather than a run of loose fields.
-///
-/// Open, the three settings used to flow at the same level as the model picker
-/// and the Start button, so a form with **one** decision in it looked like a
-/// form with six. Nothing said the fields belonged to the sentence that revealed
-/// them, or to each other.
-///
-/// A plate says both at once, and its two surfaces are picked by measurement
-/// rather than by taste.
-///
-/// **Lifted, not recessed.** [AdvertiseAsField] and [NodeNameField] both fill
-/// themselves [AppCard.inset]; a recessed plate would be that same `#F7F7F5`
-/// and the fields would vanish into it. White keeps them readable as insets.
-///
-/// **Rimmed with [AppGlass.lift], not [AppCard.hair].** In light this plate is
-/// `#FFFFFF` on a block that is *also* `#FFFFFF` ([AppGlass.surfaceFill]) — 1:1,
-/// so fill does no work at all here and the edge is the whole separation (§2).
-/// `hair` is 6% black and disappears on a white pane, which is the case `lift`
-/// exists for. The shadow carries the rest.
-///
-/// A rule splits the two questions inside it, because what the grid calls this
-/// and how much it remembers are not the same kind of setting.
-class _DetailsPanel extends StatelessWidget {
-  const _DetailsPanel({required this.names, required this.window});
-
-  /// The two "what the grid sees" fields.
-  final List<Widget> names;
-
-  /// The context-window control, which answers a different question.
-  final Widget window;
-
-  @override
-  Widget build(BuildContext context) {
-    AppTheme.watch(context);
-    return Container(
-      decoration: BoxDecoration(
-        color: AppCard.base,
-        borderRadius: BorderRadius.circular(AppCard.radius),
-        border: Border.all(color: AppGlass.lift),
-        boxShadow: AppGlass.cardShadow,
-      ),
-      padding: const EdgeInsets.fromLTRB(16, 15, 16, 16),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          ...names,
-          const SizedBox(height: 16),
-          Divider(height: 1, thickness: 1, color: AppPalette.divider),
-          const SizedBox(height: 15),
-          window,
-        ],
-      ),
     );
   }
 }

--- a/lib/features/provider_node/logic/context_ladder.dart
+++ b/lib/features/provider_node/logic/context_ladder.dart
@@ -1,0 +1,42 @@
+import '../../../core/context_length.dart';
+
+/// The context sizes a picker offers for an external server, largest last.
+///
+/// The design gives the endpoint form a dropdown where the local engine gets a
+/// slider, and the reason holds: a server's window is a number it was *launched
+/// with*, so the question here is "which of these did you start it on", not
+/// "how much would you like". A ladder answers that in one press.
+///
+/// Two rules keep it honest. Nothing above [max] is offered, because the server
+/// cannot serve it. And a value already in force that is not on the ladder —
+/// `--ctx-size 40960`, or whatever the server reported about itself — is kept
+/// as its own rung, so opening the picker can never quietly round somebody's
+/// setting to the nearest familiar number.
+///
+/// Pure, so the rounding rule is a tested one rather than a chain of ifs in a
+/// `build()`.
+List<int> contextLadder({required int max, required int current}) {
+  const rungs = [
+    4 * 1024,
+    8 * 1024,
+    16 * 1024,
+    32 * 1024,
+    64 * 1024,
+    128 * 1024,
+    200 * 1024,
+    256 * 1024,
+    512 * 1024,
+    1024 * 1024,
+  ];
+  final ceiling = max < minContextTokens ? minContextTokens : max;
+  final offered = {
+    for (final rung in rungs)
+      if (rung <= ceiling) rung,
+    // The ceiling itself, so a server that tops out at an odd number can still
+    // be run flat out.
+    ceiling,
+    // Never drop what is already set.
+    current.clamp(minContextTokens, ceiling),
+  }.toList()..sort();
+  return offered;
+}

--- a/lib/features/provider_node/logic/share_route.dart
+++ b/lib/features/provider_node/logic/share_route.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// The three ways this computer can put intelligence on a grid.
+///
+/// One axis, three values, and every state of the page is one of them plus
+/// "already sharing". They were three stacked disclosures before: rows you
+/// opened one at a time, each unfolding a form under the two you hadn't read.
+/// That shape asks the reader to compare options by opening and closing them.
+/// As a route picked on the left and configured on the right, all three stay
+/// visible while one is being set up.
+enum ShareRoute { local, key, server }
+
+/// Which route the page opens on, given what this machine can actually do.
+///
+/// Never a route the machine can't take: opening on "run a model here" for a
+/// computer with no built-in engine support puts a form in front of someone
+/// whose first move has to be somewhere else. Local leads when it is possible
+/// because it is the only route that costs nothing and sends nothing — an
+/// answer the other two can't give.
+///
+/// Pure, so the ordering is a tested rule rather than a chain of `??` in a
+/// `build()`.
+ShareRoute defaultShareRoute({
+  required bool canRunLocal,
+  required bool serverFound,
+  required bool hasKeyProvider,
+}) {
+  if (canRunLocal) return ShareRoute.local;
+  // Something is already running on this machine — one press from shared, and
+  // no download.
+  if (serverFound) return ShareRoute.server;
+  if (hasKeyProvider) return ShareRoute.key;
+  // The endpoint form takes a typed address, so it is the one route that is
+  // always available even when nothing was detected and no provider is
+  // whitelisted.
+  return ShareRoute.server;
+}
+
+/// The route the reader picked, or null while the page still follows
+/// [defaultShareRoute].
+///
+/// Null rather than a seeded value on purpose: detection lands a frame or two
+/// after the page opens, and a controller that had to be *told* the default
+/// would need a side effect in `build()` to do it (§2).
+final shareRouteProvider = NotifierProvider<ShareRouteController, ShareRoute?>(
+  ShareRouteController.new,
+);
+
+/// Holds the reader's choice of route for as long as the app is open.
+class ShareRouteController extends Notifier<ShareRoute?> {
+  @override
+  ShareRoute? build() => null;
+
+  void pick(ShareRoute route) => state = route;
+}

--- a/lib/features/provider_node/logic/share_route_offer.dart
+++ b/lib/features/provider_node/logic/share_route_offer.dart
@@ -54,7 +54,7 @@ List<ShareRouteOffer> buildShareRouteOffers({
     if (canRunLocal)
       ShareRouteOffer(
         route: ShareRoute.local,
-        title: 'Run a model here',
+        title: 'Run a local model',
         line: needsSetup
             ? 'Sets up the built-in engine first, then runs a model here.'
             : 'Your own hardware does the work. Weights and prompts never '
@@ -63,27 +63,41 @@ List<ShareRouteOffer> buildShareRouteOffers({
     if (keyProviders.isNotEmpty)
       ShareRouteOffer(
         route: ShareRoute.key,
-        title: 'Use a key you pay for',
-        // Named from what the installed CLI whitelists, never a hopeful list:
-        // "your OpenAI key" on a build that serves someone else's is a
-        // sentence pointing at a provider this machine cannot reach.
-        line: 'Nothing to download. ${apiKeyCardLine(apiEngines)}.',
+        // "Frontier" is a word §5 would normally send back — and the line
+        // under it explains the term by example, which is what that rule
+        // actually asks for: a reader who does not know it meets "OpenAI" one
+        // line down and does.
+        title: 'Share frontier models via your API key',
+        // The provider is named from what the installed CLI whitelists, never
+        // a hopeful list: "your OpenAI key" on a build that serves someone
+        // else's points at a provider this machine cannot reach. The cost sits
+        // here rather than in the title, because what it costs is a
+        // consequence of the route rather than the name of it — and a reader
+        // choosing between three cards should meet it before pressing, not in
+        // the pane afterwards.
+        line:
+            'Nothing to download. ${apiKeyCardLine(apiEngines)}, and pay for '
+            'what the grid uses.',
       ),
     ShareRouteOffer(
       route: ShareRoute.server,
-      title: 'Share a server you run',
+      // The verb is about the route, not about the moment: on the common
+      // machine the engine is installed and stopped, which is exactly what
+      // this starts. The line under it carries the state, so a server already
+      // running is never told to start again.
+      title: 'Start an engine you already have',
       detected: external.length,
       line: switch ((running.firstOrNull, external.firstOrNull)) {
         // Running and merely installed are a press apart, and saying the wrong
         // one sends the reader looking for a Start button that is already a
         // Share button, or the reverse.
         (final live?, _) =>
-          '${live.label} is already running here. Share it '
+          '${live.label} is running here. Point Grid at it and share it '
               'exactly as it is.',
         (_, final found?) =>
           '${found.label} is installed here. Start it and '
               'share it as it is.',
-        _ => 'Point Grid at an engine already running on this computer.',
+        _ => 'Point Grid at any OpenAI-compatible engine on this computer.',
       },
     ),
   ];

--- a/lib/features/provider_node/logic/share_route_offer.dart
+++ b/lib/features/provider_node/logic/share_route_offer.dart
@@ -3,16 +3,8 @@ import 'api_engine_choices.dart';
 import 'backend_detector.dart';
 import 'share_route.dart';
 
-/// How loud a route's badge is.
-///
-/// Two values, because there is exactly one thing on this page worth a colour:
-/// a server already running on this machine, which is the route that is one
-/// press from done. A page where every badge is bright has nothing left to
-/// point with.
-enum ShareBadgeTone { neutral, ready }
-
-/// One route as the rail draws it: what it is called, what it saves you, and
-/// one line describing it in terms of what was actually found on this machine.
+/// One route as the rail draws it: what it is called and one line describing it
+/// in terms of what was actually found on this machine.
 ///
 /// A view model rather than three literals in a `build()`, because every line
 /// here changes with what the machine has — an engine that still needs
@@ -24,15 +16,17 @@ class ShareRouteOffer {
     required this.route,
     required this.title,
     required this.line,
-    this.badge,
-    this.badgeTone = ShareBadgeTone.neutral,
+    this.detected = 0,
   });
 
   final ShareRoute route;
   final String title;
   final String line;
-  final String? badge;
-  final ShareBadgeTone badgeTone;
+
+  /// Engines found on this machine for this route — only the server route ever
+  /// finds any. The count, not a rendering of it: the rail spends it on which
+  /// line to write, and the detail pane on how to open its paragraph.
+  final int detected;
 }
 
 /// The routes this machine can take, in the order the rail shows them.
@@ -61,7 +55,6 @@ List<ShareRouteOffer> buildShareRouteOffers({
       ShareRouteOffer(
         route: ShareRoute.local,
         title: 'Run a model here',
-        badge: 'Private',
         line: needsSetup
             ? 'Sets up the built-in engine first, then runs a model here.'
             : 'Your own hardware does the work. Weights and prompts never '
@@ -71,7 +64,6 @@ List<ShareRouteOffer> buildShareRouteOffers({
       ShareRouteOffer(
         route: ShareRoute.key,
         title: 'Use a key you pay for',
-        badge: 'Instant',
         // Named from what the installed CLI whitelists, never a hopeful list:
         // "your OpenAI key" on a build that serves someone else's is a
         // sentence pointing at a provider this machine cannot reach.
@@ -80,14 +72,7 @@ List<ShareRouteOffer> buildShareRouteOffers({
     ShareRouteOffer(
       route: ShareRoute.server,
       title: 'Share a server you run',
-      badge: external.isEmpty ? null : '${external.length} found',
-      // Green the moment something is found, which is what the design does —
-      // not only when it is already answering. The card's own line separates
-      // the two states ("already running here" against "installed here"); the
-      // badge counts what was found.
-      badgeTone: external.isEmpty
-          ? ShareBadgeTone.neutral
-          : ShareBadgeTone.ready,
+      detected: external.length,
       line: switch ((running.firstOrNull, external.firstOrNull)) {
         // Running and merely installed are a press apart, and saying the wrong
         // one sends the reader looking for a Start button that is already a

--- a/lib/features/provider_node/logic/share_route_offer.dart
+++ b/lib/features/provider_node/logic/share_route_offer.dart
@@ -81,7 +81,11 @@ List<ShareRouteOffer> buildShareRouteOffers({
       route: ShareRoute.server,
       title: 'Share a server you run',
       badge: external.isEmpty ? null : '${external.length} found',
-      badgeTone: running.isEmpty
+      // Green the moment something is found, which is what the design does —
+      // not only when it is already answering. The card's own line separates
+      // the two states ("already running here" against "installed here"); the
+      // badge counts what was found.
+      badgeTone: external.isEmpty
           ? ShareBadgeTone.neutral
           : ShareBadgeTone.ready,
       line: switch ((running.firstOrNull, external.firstOrNull)) {

--- a/lib/features/provider_node/logic/share_route_offer.dart
+++ b/lib/features/provider_node/logic/share_route_offer.dart
@@ -1,0 +1,101 @@
+import 'api_engine_catalog.dart';
+import 'api_engine_choices.dart';
+import 'backend_detector.dart';
+import 'share_route.dart';
+
+/// How loud a route's badge is.
+///
+/// Two values, because there is exactly one thing on this page worth a colour:
+/// a server already running on this machine, which is the route that is one
+/// press from done. A page where every badge is bright has nothing left to
+/// point with.
+enum ShareBadgeTone { neutral, ready }
+
+/// One route as the rail draws it: what it is called, what it saves you, and
+/// one line describing it in terms of what was actually found on this machine.
+///
+/// A view model rather than three literals in a `build()`, because every line
+/// here changes with what the machine has — an engine that still needs
+/// installing, which providers this CLI whitelists, whether Ollama is running
+/// or merely present. Those are the sentences that go stale silently, so they
+/// are built in one tested place (§5).
+class ShareRouteOffer {
+  const ShareRouteOffer({
+    required this.route,
+    required this.title,
+    required this.line,
+    this.badge,
+    this.badgeTone = ShareBadgeTone.neutral,
+  });
+
+  final ShareRoute route;
+  final String title;
+  final String line;
+  final String? badge;
+  final ShareBadgeTone badgeTone;
+}
+
+/// The routes this machine can take, in the order the rail shows them.
+///
+/// A route the machine cannot take is left out rather than drawn disabled: a
+/// greyed row still has to be read, and "you can't do this" is not information
+/// a first-time reader can act on. The endpoint route is always here — it takes
+/// a typed address, so it needs nothing detected to be possible.
+List<ShareRouteOffer> buildShareRouteOffers({
+  required bool canRunLocal,
+  required bool needsSetup,
+  required List<ApiEngine> apiEngines,
+  required List<DetectedBackend> backends,
+}) {
+  final keyProviders = keyEngines(apiEngines);
+  final external = [
+    for (final b in backends)
+      if (b.isExternal) b,
+  ];
+  final running = [
+    for (final b in external)
+      if (b.running) b,
+  ];
+  return [
+    if (canRunLocal)
+      ShareRouteOffer(
+        route: ShareRoute.local,
+        title: 'Run a model here',
+        badge: 'Private',
+        line: needsSetup
+            ? 'Sets up the built-in engine first, then runs a model here.'
+            : 'Your own hardware does the work. Weights and prompts never '
+                  'leave the machine.',
+      ),
+    if (keyProviders.isNotEmpty)
+      ShareRouteOffer(
+        route: ShareRoute.key,
+        title: 'Use a key you pay for',
+        badge: 'Instant',
+        // Named from what the installed CLI whitelists, never a hopeful list:
+        // "your OpenAI key" on a build that serves someone else's is a
+        // sentence pointing at a provider this machine cannot reach.
+        line: 'Nothing to download. ${apiKeyCardLine(apiEngines)}.',
+      ),
+    ShareRouteOffer(
+      route: ShareRoute.server,
+      title: 'Share a server you run',
+      badge: external.isEmpty ? null : '${external.length} found',
+      badgeTone: running.isEmpty
+          ? ShareBadgeTone.neutral
+          : ShareBadgeTone.ready,
+      line: switch ((running.firstOrNull, external.firstOrNull)) {
+        // Running and merely installed are a press apart, and saying the wrong
+        // one sends the reader looking for a Start button that is already a
+        // Share button, or the reverse.
+        (final live?, _) =>
+          '${live.label} is already running here. Share it '
+              'exactly as it is.',
+        (_, final found?) =>
+          '${found.label} is installed here. Start it and '
+              'share it as it is.',
+        _ => 'Point Grid at an engine already running on this computer.',
+      },
+    ),
+  ];
+}

--- a/lib/features/provider_node/presentation/api_engine_block.dart
+++ b/lib/features/provider_node/presentation/api_engine_block.dart
@@ -5,9 +5,9 @@ import 'package:url_launcher/url_launcher.dart';
 import '../../../infrastructure/analytics/analytics_events.dart';
 import '../../../infrastructure/analytics/analytics_providers.dart';
 import '../../../infrastructure/state/models/network_credential.dart';
-import '../../../shared/copy/plural.dart';
 import '../../../shared/theme/app_theme.dart';
 import '../../../shared/widgets/app_select_field.dart';
+import '../../../shared/theme/share_page_theme.dart';
 import '../../../shared/widgets/form_plate.dart';
 import '../../../shared/widgets/app_spinner.dart';
 import '../../../shared/widgets/labeled_field.dart';
@@ -297,29 +297,30 @@ class _ApiEngineFormState extends ConsumerState<ApiEngineForm> {
                     onReplaceKey: () => setState(() => _replaceKey = true),
                     onOpenHelp: _openUrl,
                   ),
-                const SizedBox(height: 10),
-                Text(
-                  // The "Billed to your own account" chip above already says
-                  // who pays, so this keeps only what the chip doesn't carry:
-                  // for a seat, that the allowance being spent is the one on
-                  // this computer; for a key, where the key lives and where
-                  // prompts go. Under the field it belongs to now, rather than
-                  // at the foot of the form, where it answered a question the
-                  // reader had two controls ago.
-                  engine.provider.isSeat
-                      ? 'Requests run through ${engine.provider.label} here '
-                            'and spend its own allowance.'
-                      : 'Your key never leaves this computer. Questions go to '
-                            '${engine.provider.label} to be answered.',
-                  style: quiet,
-                ),
+                // A seat spends an allowance rather than a key, and has no
+                // field of its own to hang the note under — so it keeps it
+                // here. The key path carries its own, inside [_KeyField].
+                if (engine.provider.isSeat) ...[
+                  const SizedBox(height: 10),
+                  Text(
+                    'Requests run through ${engine.provider.label} here and '
+                    'spend its own allowance.',
+                    style: quiet,
+                  ),
+                ],
               ],
             ),
             Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
+                FieldLabel("Models you're willing to share"),
+                Text(
+                  'Only the ones you pick get offered to the grid.',
+                  style: quiet,
+                ),
+                const SizedBox(height: 10),
                 if (!widget.compact || _showAdvanced)
-                  _ModelMultiSelect(
+                  _ModelPills(
                     models: engine.models,
                     selected: _selected,
                     alreadyShared: widget.alreadyShared,
@@ -328,20 +329,17 @@ class _ApiEngineFormState extends ConsumerState<ApiEngineForm> {
                 else
                   Align(
                     alignment: Alignment.centerLeft,
-                    child: TextButton.icon(
+                    child: TextButton(
                       onPressed: () => setState(() => _showAdvanced = true),
-                      icon: const Icon(Icons.tune, size: 16),
-                      label: const Text('Choose which models to share'),
+                      child: const Text('Choose which models to share →'),
                     ),
                   ),
-                const SizedBox(height: 8),
-                Text(
-                  'Only the ones you pick get offered to the grid.',
-                  style: quiet,
-                ),
                 if (!widget.compact && engine.lastVerified.isNotEmpty) ...[
-                  const SizedBox(height: 6),
+                  const SizedBox(height: 10),
                   Text(
+                    // Not in the design, and kept: a model list this app can
+                    // only refresh by shipping a new build is a fact the reader
+                    // needs when the model they are looking for is missing.
                     'Model list updated ${_prettyDate(engine.lastVerified)}. '
                     'Update Grid to refresh.',
                     style: quiet,
@@ -352,19 +350,35 @@ class _ApiEngineFormState extends ConsumerState<ApiEngineForm> {
           ],
         ),
         const SizedBox(height: 18),
-        Align(
-          alignment: Alignment.centerLeft,
-          child: starting
-              ? const _StartingRow(label: 'Starting…')
-              : ListenableBuilder(
-                  listenable: _key,
-                  builder: (context, _) => EngineStartButton(
+        if (starting)
+          const Align(
+            alignment: Alignment.centerLeft,
+            child: _StartingRow(label: 'Starting…'),
+          )
+        else
+          ListenableBuilder(
+            listenable: _key,
+            builder: (context, _) {
+              final blocked = _startBlockedReason();
+              return Wrap(
+                spacing: ShareMetrics.buttonGap,
+                runSpacing: 8,
+                crossAxisAlignment: WrapCrossAlignment.center,
+                children: [
+                  EngineStartButton(
                     label: _startLabel,
-                    blockedReason: _startBlockedReason(),
+                    blockedReason: blocked,
                     onPressed: _start,
                   ),
-                ),
-        ),
+                  // Beside the button rather than only inside its tooltip: a
+                  // disabled control that will not say why is the shape people
+                  // stare at.
+                  if (blocked != null)
+                    Text(blocked, style: ShareType.buttonHelper),
+                ],
+              );
+            },
+          ),
       ],
     );
   }
@@ -548,13 +562,22 @@ class _KeyField extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        const FieldLabel('Provider API key'),
+        // Named for the provider it belongs to, as the design has it: on a
+        // build that whitelists one provider, "Provider API key" makes the
+        // reader work out which provider from the dropdown that isn't there.
+        FieldLabel('${provider.label} API key'),
         TextField(
           controller: controller,
           obscureText: obscure,
           autocorrect: false,
           enableSuggestions: false,
-          style: kFieldTextStyle,
+          // Mono, as the design sets it: a key is a string you check character
+          // by character, and `l`/`1` and `O`/`0` are the two pairs a
+          // proportional face makes hardest to tell apart.
+          style: kFieldTextStyle.copyWith(
+            fontFamily: AppFont.monoDefault,
+            letterSpacing: 0.2,
+          ),
           decoration:
               labeledFieldDecoration(
                 provider.keyHint,
@@ -576,26 +599,47 @@ class _KeyField extends StatelessWidget {
                 ),
               ),
         ),
-        if (helpUrl != null)
-          Align(
-            alignment: Alignment.centerLeft,
-            child: TextButton.icon(
-              onPressed: () => onOpenHelp(helpUrl),
-              icon: const Icon(Icons.open_in_new, size: 16),
-              label: const Text('Find your API key'),
+        const SizedBox(height: 4),
+        // The way to the key and the promise about it, on one line under the
+        // field they both belong to. The design puts "Read-only checks only.
+        // No billing changes." here, and this app cannot say it: the key is
+        // used to *answer questions*, which is exactly what bills the account.
+        // What it can say is where the key lives and where the questions go.
+        Wrap(
+          spacing: 14,
+          runSpacing: 4,
+          crossAxisAlignment: WrapCrossAlignment.center,
+          children: [
+            if (helpUrl != null)
+              TextButton(
+                onPressed: () => onOpenHelp(helpUrl),
+                child: const Text('Where to find your key →'),
+              ),
+            Text(
+              'Your key never leaves this computer. Questions go to '
+              '${provider.label} to be answered.',
+              style: ShareType.note,
             ),
-          ),
+          ],
+        ),
       ],
     );
   }
 }
 
-/// A compact multi-select for the whitelisted models: a field showing a summary
-/// ("All available models (4)" / "2 of 4 models") that drops a checkbox menu.
-/// All are shared by default; the menu stays open while ticking so several can
-/// be picked in one go. Keeps the block short instead of a full checkbox list.
-class _ModelMultiSelect extends StatelessWidget {
-  const _ModelMultiSelect({
+/// The whitelisted models as pills you switch on and off.
+///
+/// The design's control, and the right one for this list: every model is a
+/// yes/no, they are short, and there are a handful. A dropdown summarising them
+/// as "All available models (4)" made the reader open a menu to find out what
+/// the four *were* — which is the same mistake the three stacked routes used to
+/// make, one control down.
+///
+/// A model this machine already serves is shown, spent, and untappable: sharing
+/// one twice would advertise the same name to the grid twice, and leaving it out
+/// would make it look as though the provider never offered it.
+class _ModelPills extends StatelessWidget {
+  const _ModelPills({
     required this.models,
     required this.selected,
     required this.alreadyShared,
@@ -604,223 +648,93 @@ class _ModelMultiSelect extends StatelessWidget {
 
   final List<ApiEngineModel> models;
   final Set<String> selected;
-
-  /// Models this machine already serves — shown, but not tickable: sharing one
-  /// twice would advertise the same name to the grid twice.
   final Set<String> alreadyShared;
   final void Function(String advertised, bool selected) onToggle;
 
   @override
-  Widget build(BuildContext context) {
-    // The menu opens full-width (not shrink-wrapped to the model names), so each
-    // row carries the field width via a SizedBox — MenuStyle.minimumSize doesn't
-    // widen the panel reliably. LayoutBuilder gives us that width.
-    return LayoutBuilder(
-      builder: (context, constraints) => MenuAnchor(
-        // Line the menu up under the field's left edge, just below it.
-        alignmentOffset: const Offset(0, 6),
-        // Without this the panel takes the themed fill, which is within 1.02:1
-        // of the block behind it (identical in light) — the menu had no edge.
-        style: appMenuStyle(),
-        builder: (context, controller, _) => _ModelField(
-          summary: _summary(),
-          onTap: controller.isOpen ? controller.close : controller.open,
+  Widget build(BuildContext context) => Wrap(
+    spacing: 8,
+    runSpacing: 8,
+    children: [
+      for (final model in models)
+        _ModelPill(
+          // "openai:gpt-5.4" is the name the grid advertises, and every pill
+          // here carries the same prefix — a column of it says nothing the
+          // label above has not, and it is what pushed four short names onto
+          // two rows.
+          label: model.advertised.split(':').last,
+          state: alreadyShared.contains(model.advertised)
+              ? _PillState.shared
+              : selected.contains(model.advertised)
+              ? _PillState.on
+              : _PillState.off,
+          onToggle: () =>
+              onToggle(model.advertised, !selected.contains(model.advertised)),
         ),
-        menuChildren: [
-          for (final model in models)
-            _ModelMenuRow(
-              model: model,
-              width: constraints.maxWidth,
-              checked: selected.contains(model.advertised),
-              shared: alreadyShared.contains(model.advertised),
-              onToggle: () => onToggle(
-                model.advertised,
-                !selected.contains(model.advertised),
-              ),
-            ),
-        ],
-      ),
-    );
-  }
-
-  /// What the field says when closed. Counts against what's actually on offer —
-  /// with some models already live, "all" means all the ones left to share, and
-  /// nothing to share at all says so rather than reading "No models selected".
-  String _summary() {
-    final offered = models.length - alreadyShared.length;
-    if (offered <= 0) return 'Already sharing every model';
-    if (selected.isEmpty) return 'No models selected';
-    if (selected.length == offered) {
-      return offered == models.length
-          ? 'All available models ($offered)'
-          : 'All $offered ${plural(offered, 'model')} left to share';
-    }
-    return '${selected.length} of $offered ${plural(offered, 'model')}';
-  }
+    ],
+  );
 }
 
-/// The tappable field that opens the model menu: a borderless capsule matching
-/// the app's other fields, showing the current [summary] with a dropdown
-/// affordance.
-class _ModelField extends StatelessWidget {
-  const _ModelField({required this.summary, required this.onTap});
+enum _PillState { on, off, shared }
 
-  final String summary;
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    AppTheme.watch(context);
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        const FieldLabel('Models you are willing to share'),
-        InkWell(
-          onTap: onTap,
-          borderRadius: BorderRadius.circular(12),
-          child: InputDecorator(
-            isEmpty: false,
-            decoration: labeledFieldDecoration(
-              '',
-              fill: AppCard.inset,
-              skin: FieldSkinScope.maybeOf(context),
-            ),
-            child: Row(
-              children: [
-                Expanded(
-                  child: Text(
-                    summary,
-                    overflow: TextOverflow.ellipsis,
-                    style: kFieldTextStyle,
-                  ),
-                ),
-                // Size 24 (a dropdown's default arrow) so the field matches the
-                // theme's field height instead of shrinking to the 18px icon
-                // theme.
-                const Icon(Icons.arrow_drop_down, size: 24),
-              ],
-            ),
-          ),
-        ),
-      ],
-    );
-  }
-}
-
-/// One checkbox row in the model menu — the model name over its context/notes,
-/// stretched to the field [width]. Toggling never closes the menu, so several
-/// can be picked in a pass.
-class _ModelMenuRow extends StatelessWidget {
-  const _ModelMenuRow({
-    required this.model,
-    required this.width,
-    required this.checked,
-    required this.shared,
+/// One model, and whether the grid may ask for it.
+class _ModelPill extends StatelessWidget {
+  const _ModelPill({
+    required this.label,
+    required this.state,
     required this.onToggle,
   });
 
-  final ApiEngineModel model;
-  final double width;
-  final bool checked;
-
-  /// Already live on the grid from this machine — the row shows it, greyed and
-  /// untickable, so the model is accounted for rather than silently missing.
-  final bool shared;
+  final String label;
+  final _PillState state;
   final VoidCallback onToggle;
+
+  String get _suffix => switch (state) {
+    _PillState.on => 'on',
+    _PillState.off => 'off',
+    _PillState.shared => 'sharing',
+  };
 
   @override
   Widget build(BuildContext context) {
     AppTheme.watch(context);
-    final theme = Theme.of(context);
-    final radius = BorderRadius.circular(AppControl.radius);
-    // Same construction as AppSelectField's rows and the chat model picker's:
-    // MenuItemButton is unthemed here, so its M3 defaults (square corners, 14pt
-    // text, Material's grey hover, an ink ripple) would put this menu outside
-    // the design system. See _OptionRow in app_select_field.dart.
-    return SizedBox(
-      width: width,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
-        child: Material(
-          color: Colors.transparent,
-          borderRadius: radius,
-          child: InkWell(
-            onTap: shared ? null : onToggle,
-            borderRadius: radius,
-            hoverColor: AppSurface.hoverFill,
-            splashFactory: NoSplash.splashFactory,
-            child: Ink(
-              decoration: BoxDecoration(
-                color: checked ? AppSurface.accentWash : Colors.transparent,
-                borderRadius: radius,
-              ),
-              padding: const EdgeInsets.symmetric(horizontal: 9, vertical: 8),
-              child: Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Icon(
-                    shared
-                        ? Icons.check_circle_outline
-                        : (checked
-                              ? Icons.check_box
-                              : Icons.check_box_outline_blank),
-                    size: AppControl.iconSize,
-                    // onSurfaceVariant, not textFaint: on the lifted menu panel
-                    // the faint ink lands at 2.80:1, under the 3.0 WCAG 1.4.11
-                    // asks of a UI glyph.
-                    color: checked
-                        ? AppPalette.accentMuted
-                        : theme.colorScheme.onSurfaceVariant,
-                  ),
-                  const SizedBox(width: 9),
-                  Expanded(
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        // Weight carries the selection as well as the tick, so
-                        // which rows are in play reads from the text alone.
-                        Text(
-                          model.vendorName,
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                          style: TextStyle(
-                            fontSize: AppControl.fontSize,
-                            height: 1.2,
-                            fontWeight: checked
-                                ? FontWeight.w600
-                                : FontWeight.w400,
-                            color: shared
-                                ? AppPalette.textSecondary
-                                : AppPalette.textPrimary,
-                          ),
-                        ),
-                        const SizedBox(height: 3),
-                        Text(
-                          shared ? 'Already sharing' : _meta(model),
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                          style: TextStyle(
-                            fontSize: 12,
-                            height: 1.28,
-                            color: AppPalette.textSecondary,
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ),
+    final live = state != _PillState.off;
+    final pill = Container(
+      padding: const EdgeInsets.symmetric(horizontal: 11, vertical: 6),
+      decoration: BoxDecoration(
+        color: live
+            ? SharePalette.accent.withValues(alpha: 0.09)
+            : SharePalette.fieldFill,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(
+          color: live
+              ? SharePalette.accent.withValues(alpha: 0.28)
+              : SharePalette.fieldRim,
+        ),
+      ),
+      child: Text(
+        '$label · $_suffix',
+        style: TextStyle(
+          fontSize: 12.5,
+          fontWeight: AppFont.medium,
+          color: live ? SharePalette.accentHover : SharePalette.body,
         ),
       ),
     );
-  }
-
-  static String _meta(ApiEngineModel model) {
-    final ctx = '${_ctxLabel(model.contextWindow)} context';
-    return model.notes.isEmpty ? ctx : '$ctx · ${model.notes}';
+    if (state == _PillState.shared) {
+      return Tooltip(
+        message: 'Already shared with the grid from this computer.',
+        child: Opacity(opacity: 0.7, child: pill),
+      );
+    }
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: onToggle,
+        child: pill,
+      ),
+    );
   }
 }
 
@@ -848,17 +762,4 @@ String _prettyDate(String iso) {
   final day = int.tryParse(parts[2]);
   if (month == null || day == null || month < 1 || month > 12) return iso;
   return '$day ${_monthAbbr[month - 1]} ${parts[0]}';
-}
-
-/// A compact context-window label, e.g. `1.1M` / `400K` — a hint, not exact.
-String _ctxLabel(int tokens) {
-  if (tokens >= 1000000) {
-    final millions = tokens / 1000000;
-    final text = millions == millions.roundToDouble()
-        ? millions.toStringAsFixed(0)
-        : millions.toStringAsFixed(1);
-    return '${text}M';
-  }
-  if (tokens >= 1000) return '${(tokens / 1000).round()}K';
-  return '$tokens';
 }

--- a/lib/features/provider_node/presentation/api_engine_block.dart
+++ b/lib/features/provider_node/presentation/api_engine_block.dart
@@ -8,6 +8,7 @@ import '../../../infrastructure/state/models/network_credential.dart';
 import '../../../shared/copy/plural.dart';
 import '../../../shared/theme/app_theme.dart';
 import '../../../shared/widgets/app_select_field.dart';
+import '../../../shared/widgets/form_plate.dart';
 import '../../../shared/widgets/app_spinner.dart';
 import '../../../shared/widgets/labeled_field.dart';
 import '../logic/api_engine_catalog.dart';
@@ -248,84 +249,109 @@ class _ApiEngineFormState extends ConsumerState<ApiEngineForm> {
         run is ProviderRunActive &&
         run.grid == widget.network.networkId &&
         run.starting;
+    final theme = Theme.of(context);
+    final quiet = theme.textTheme.bodySmall?.copyWith(
+      color: theme.colorScheme.onSurfaceVariant,
+    );
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        if (widget.engines.length > 1) ...[
-          _ProviderDropdown(
-            engines: widget.engines,
-            selectedKind: _kind,
-            onChanged: _onProviderChanged,
-          ),
-          const SizedBox(height: 12),
-        ],
-        if (engine.provider.isSeat) ...[
-          _SeatPanel(
-            provider: engine.provider,
-            found: engine.seatFound == true,
-            onOpenSetup: _openUrl,
-          ),
-          // Only under the Claude seat: a distributed task runs Claude Code,
-          // so this is the one join whose environment the task loop reads.
-          if (engine.provider.kind == kClaudeSeatKind) ...[
-            const SizedBox(height: 16),
-            const Divider(height: 1),
-            const SizedBox(height: 12),
-            const TaskServingPanel(),
+        // Two questions, ruled apart: whose account answers, and which of its
+        // models this grid is allowed to ask for. They used to run together
+        // down one column, where the second read as more of the first.
+        FormPlate(
+          sections: [
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                if (widget.engines.length > 1) ...[
+                  _ProviderDropdown(
+                    engines: widget.engines,
+                    selectedKind: _kind,
+                    onChanged: _onProviderChanged,
+                  ),
+                  const SizedBox(height: 12),
+                ],
+                if (engine.provider.isSeat) ...[
+                  _SeatPanel(
+                    provider: engine.provider,
+                    found: engine.seatFound == true,
+                    onOpenSetup: _openUrl,
+                  ),
+                  // Only under the Claude seat: a distributed task runs Claude
+                  // Code, so this is the one join whose environment the task
+                  // loop reads.
+                  if (engine.provider.kind == kClaudeSeatKind) ...[
+                    const SizedBox(height: 16),
+                    const Divider(height: 1),
+                    const SizedBox(height: 12),
+                    const TaskServingPanel(),
+                  ],
+                ] else
+                  _KeyField(
+                    provider: engine.provider,
+                    controller: _key,
+                    obscure: _obscure,
+                    usingStoredKey: _usingStoredKey,
+                    onToggleObscure: () => setState(() => _obscure = !_obscure),
+                    onReplaceKey: () => setState(() => _replaceKey = true),
+                    onOpenHelp: _openUrl,
+                  ),
+                const SizedBox(height: 10),
+                Text(
+                  // The "Billed to your own account" chip above already says
+                  // who pays, so this keeps only what the chip doesn't carry:
+                  // for a seat, that the allowance being spent is the one on
+                  // this computer; for a key, where the key lives and where
+                  // prompts go. Under the field it belongs to now, rather than
+                  // at the foot of the form, where it answered a question the
+                  // reader had two controls ago.
+                  engine.provider.isSeat
+                      ? 'Requests run through ${engine.provider.label} here '
+                            'and spend its own allowance.'
+                      : 'Your key never leaves this computer. Questions go to '
+                            '${engine.provider.label} to be answered.',
+                  style: quiet,
+                ),
+              ],
+            ),
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                if (!widget.compact || _showAdvanced)
+                  _ModelMultiSelect(
+                    models: engine.models,
+                    selected: _selected,
+                    alreadyShared: widget.alreadyShared,
+                    onToggle: _toggleModel,
+                  )
+                else
+                  Align(
+                    alignment: Alignment.centerLeft,
+                    child: TextButton.icon(
+                      onPressed: () => setState(() => _showAdvanced = true),
+                      icon: const Icon(Icons.tune, size: 16),
+                      label: const Text('Choose which models to share'),
+                    ),
+                  ),
+                const SizedBox(height: 8),
+                Text(
+                  'Only the ones you pick get offered to the grid.',
+                  style: quiet,
+                ),
+                if (!widget.compact && engine.lastVerified.isNotEmpty) ...[
+                  const SizedBox(height: 6),
+                  Text(
+                    'Model list updated ${_prettyDate(engine.lastVerified)}. '
+                    'Update Grid to refresh.',
+                    style: quiet,
+                  ),
+                ],
+              ],
+            ),
           ],
-        ] else
-          _KeyField(
-            provider: engine.provider,
-            controller: _key,
-            obscure: _obscure,
-            usingStoredKey: _usingStoredKey,
-            onToggleObscure: () => setState(() => _obscure = !_obscure),
-            onReplaceKey: () => setState(() => _replaceKey = true),
-            onOpenHelp: _openUrl,
-          ),
-        const SizedBox(height: 16),
-        if (!widget.compact || _showAdvanced)
-          _ModelMultiSelect(
-            models: engine.models,
-            selected: _selected,
-            alreadyShared: widget.alreadyShared,
-            onToggle: _toggleModel,
-          )
-        else
-          Align(
-            alignment: Alignment.centerLeft,
-            child: TextButton.icon(
-              onPressed: () => setState(() => _showAdvanced = true),
-              icon: const Icon(Icons.tune, size: 16),
-              label: const Text('Advanced: choose which models to share'),
-            ),
-          ),
-        if (!widget.compact && engine.lastVerified.isNotEmpty) ...[
-          const SizedBox(height: 6),
-          Text(
-            'Model list updated ${_prettyDate(engine.lastVerified)}. '
-            'Update Grid to refresh.',
-            style: Theme.of(context).textTheme.bodySmall?.copyWith(
-              color: Theme.of(context).colorScheme.onSurfaceVariant,
-            ),
-          ),
-        ],
-        const SizedBox(height: 12),
-        Text(
-          // The "Billed to your own account" chip above already says who pays,
-          // so this keeps only what the chip doesn't carry: for a seat, that the
-          // allowance being spent is the one on this computer; for a key, where
-          // the key lives and where prompts go.
-          engine.provider.isSeat
-              ? 'Requests run through ${engine.provider.label} here and spend '
-                    'its own allowance.'
-              : 'Your key never leaves this computer. Questions go to '
-                    '${engine.provider.label} to be answered.',
-          style: Theme.of(context).textTheme.bodySmall?.copyWith(
-            color: Theme.of(context).colorScheme.onSurfaceVariant,
-          ),
         ),
-        const SizedBox(height: 16),
+        const SizedBox(height: 18),
         Align(
           alignment: Alignment.centerLeft,
           child: starting
@@ -647,7 +673,7 @@ class _ModelField extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        const FieldLabel('Models available to the grid'),
+        const FieldLabel('Models you are willing to share'),
         InkWell(
           onTap: onTap,
           borderRadius: BorderRadius.circular(12),

--- a/lib/features/provider_node/presentation/api_engine_block.dart
+++ b/lib/features/provider_node/presentation/api_engine_block.dart
@@ -559,6 +559,7 @@ class _KeyField extends StatelessWidget {
               labeledFieldDecoration(
                 provider.keyHint,
                 fill: AppCard.inset,
+                skin: FieldSkinScope.maybeOf(context),
               ).copyWith(
                 // Cap the toggle so it doesn't inflate the field above the theme's
                 // field height (a bare IconButton is 48, the field is 44).
@@ -679,7 +680,11 @@ class _ModelField extends StatelessWidget {
           borderRadius: BorderRadius.circular(12),
           child: InputDecorator(
             isEmpty: false,
-            decoration: labeledFieldDecoration('', fill: AppCard.inset),
+            decoration: labeledFieldDecoration(
+              '',
+              fill: AppCard.inset,
+              skin: FieldSkinScope.maybeOf(context),
+            ),
             child: Row(
               children: [
                 Expanded(

--- a/lib/features/provider_node/presentation/api_engine_block.dart
+++ b/lib/features/provider_node/presentation/api_engine_block.dart
@@ -334,17 +334,6 @@ class _ApiEngineFormState extends ConsumerState<ApiEngineForm> {
                       child: const Text('Choose which models to share →'),
                     ),
                   ),
-                if (!widget.compact && engine.lastVerified.isNotEmpty) ...[
-                  const SizedBox(height: 10),
-                  Text(
-                    // Not in the design, and kept: a model list this app can
-                    // only refresh by shipping a new build is a fact the reader
-                    // needs when the model they are looking for is missing.
-                    'Model list updated ${_prettyDate(engine.lastVerified)}. '
-                    'Update Grid to refresh.',
-                    style: quiet,
-                  ),
-                ],
               ],
             ),
           ],
@@ -600,28 +589,17 @@ class _KeyField extends StatelessWidget {
               ),
         ),
         const SizedBox(height: 4),
-        // The way to the key and the promise about it, on one line under the
-        // field they both belong to. The design puts "Read-only checks only.
-        // No billing changes." here, and this app cannot say it: the key is
-        // used to *answer questions*, which is exactly what bills the account.
-        // What it can say is where the key lives and where the questions go.
-        Wrap(
-          spacing: 14,
-          runSpacing: 4,
-          crossAxisAlignment: WrapCrossAlignment.center,
-          children: [
-            if (helpUrl != null)
-              TextButton(
-                onPressed: () => onOpenHelp(helpUrl),
-                child: const Text('Where to find your key →'),
-              ),
-            Text(
-              'Your key never leaves this computer. Questions go to '
-              '${provider.label} to be answered.',
-              style: ShareType.note,
+        // The way to the key, and nothing else. The design puts "Read-only
+        // checks only. No billing changes." beside it, which this app cannot
+        // say — the key answers questions, which is what bills the account.
+        if (helpUrl != null)
+          Align(
+            alignment: Alignment.centerLeft,
+            child: TextButton(
+              onPressed: () => onOpenHelp(helpUrl),
+              child: const Text('Where to find your key →'),
             ),
-          ],
-        ),
+          ),
       ],
     );
   }
@@ -736,30 +714,4 @@ class _ModelPill extends StatelessWidget {
       ),
     );
   }
-}
-
-const _monthAbbr = [
-  'Jan',
-  'Feb',
-  'Mar',
-  'Apr',
-  'May',
-  'Jun',
-  'Jul',
-  'Aug',
-  'Sep',
-  'Oct',
-  'Nov',
-  'Dec',
-];
-
-/// `2026-07-08` → `8 Jul 2026`; returns the input unchanged if it isn't an ISO
-/// date, so a reformatted CLI value never blanks the freshness note.
-String _prettyDate(String iso) {
-  final parts = iso.split('-');
-  if (parts.length != 3) return iso;
-  final month = int.tryParse(parts[1]);
-  final day = int.tryParse(parts[2]);
-  if (month == null || day == null || month < 1 || month > 12) return iso;
-  return '$day ${_monthAbbr[month - 1]} ${parts[0]}';
 }

--- a/lib/features/provider_node/presentation/external_server_block.dart
+++ b/lib/features/provider_node/presentation/external_server_block.dart
@@ -8,7 +8,8 @@ import '../../../infrastructure/analytics/analytics_providers.dart';
 import '../../../infrastructure/state/models/network_credential.dart';
 import '../../../shared/widgets/advertise_as_field.dart';
 import '../../../shared/widgets/app_select_field.dart';
-import '../../../shared/widgets/context_window_field.dart';
+import '../../../shared/theme/share_page_theme.dart';
+import '../logic/context_ladder.dart';
 import '../../../shared/widgets/form_plate.dart';
 import '../../../shared/widgets/labeled_field.dart';
 import '../../../shared/widgets/node_name_field.dart';
@@ -28,9 +29,9 @@ class ExternalServerBlock extends ConsumerStatefulWidget {
   const ExternalServerBlock({
     super.key,
     required this.network,
-    required this.icon,
-    required this.title,
-    required this.subtitle,
+    this.icon,
+    this.title,
+    this.subtitle,
     this.initialEndpoint = '',
     this.initialModel = '',
     this.initialAdvertise = '',
@@ -39,9 +40,12 @@ class ExternalServerBlock extends ConsumerStatefulWidget {
   });
 
   final NetworkCredential network;
-  final IconData icon;
-  final String title;
-  final String subtitle;
+
+  /// The header this block draws above its form, or null for a block that is
+  /// the whole pane and has already been named by what sits above it.
+  final IconData? icon;
+  final String? title;
+  final String? subtitle;
   final String initialEndpoint;
   final String initialModel;
   final String initialAdvertise;
@@ -308,18 +312,20 @@ class _ExternalServerBlockState extends ConsumerState<ExternalServerBlock> {
       onRetry: _retry,
       onStart: _start,
     );
+    final title = widget.title;
+    if (title == null) return form;
     if (widget.collapsible) {
       return CollapsibleEngineBlock(
-        icon: widget.icon,
-        title: widget.title,
-        subtitle: widget.subtitle,
+        icon: widget.icon!,
+        title: title,
+        subtitle: widget.subtitle!,
         child: form,
       );
     }
     return EngineBlock(
-      icon: widget.icon,
-      title: widget.title,
-      subtitle: widget.subtitle,
+      icon: widget.icon!,
+      title: title,
+      subtitle: widget.subtitle!,
       child: form,
     );
   }
@@ -369,9 +375,11 @@ class ServerForm extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        // Five fields in one column read as five steps. Ruled into three
-        // groups they read as what they are: where the engine is, what it is
-        // called, and how much it remembers.
+        // One plate, one grid. The design puts all five in a 2-column block
+        // with the address across the top, and it is right to: unlike the local
+        // engine's form, these are not three questions of different kinds — they
+        // are five facts about one server, and ruling them apart implied a
+        // sequence that isn't there.
         FormPlate(
           sections: [
             Column(
@@ -383,40 +391,51 @@ class ServerForm extends StatelessWidget {
                   reach: reach,
                   onRetry: onRetry,
                 ),
-                const SizedBox(height: 14),
-                ModelField(model: model, suggestedModels: suggestedModels),
+                const SizedBox(height: 16),
+                FieldPair(
+                  first: ModelField(
+                    model: model,
+                    suggestedModels: suggestedModels,
+                  ),
+                  second: AdvertiseAsField(
+                    controller: advertise,
+                    hintText: 'Optional, defaults to model id',
+                  ),
+                ),
+                const SizedBox(height: 16),
+                FieldPair(
+                  first: _ContextSelect(
+                    max: contextMax,
+                    value: contextValue,
+                    note: contextNote,
+                    onChanged: onContextChanged,
+                  ),
+                  second: NodeNameField(controller: nodeName),
+                ),
               ],
-            ),
-            FieldPair(
-              first: AdvertiseAsField(
-                controller: advertise,
-                hintText: 'qwen3-31b.gguf',
-                optional: true,
-              ),
-              second: NodeNameField(controller: nodeName),
-            ),
-            ContextWindowField(
-              max: contextMax,
-              value: contextValue,
-              note: contextNote,
-              // Already inside a plate that rules it off from the fields above,
-              // so the recessed tile would be a box inside a box.
-              inline: true,
-              onChanged: onContextChanged,
             ),
           ],
         ),
         const SizedBox(height: 18),
-        Align(
-          alignment: Alignment.centerLeft,
-          child: ListenableBuilder(
-            listenable: Listenable.merge([endpoint, model]),
-            builder: (context, _) => EngineStartButton(
-              label: checking ? 'Checking…' : 'Start engine',
-              blockedReason: _blockedReason(),
-              onPressed: onStart,
-            ),
-          ),
+        ListenableBuilder(
+          listenable: Listenable.merge([endpoint, model]),
+          builder: (context, _) {
+            final blocked = _blockedReason();
+            return Wrap(
+              spacing: ShareMetrics.buttonGap,
+              runSpacing: 8,
+              crossAxisAlignment: WrapCrossAlignment.center,
+              children: [
+                EngineStartButton(
+                  label: checking ? 'Checking…' : 'Start engine',
+                  blockedReason: blocked,
+                  onPressed: onStart,
+                ),
+                if (blocked != null)
+                  Text(blocked, style: ShareType.buttonHelper),
+              ],
+            );
+          },
         ),
       ],
     );
@@ -435,7 +454,10 @@ class ServerForm extends StatelessWidget {
   String? _blockedReason() {
     if (checking) return 'Checking the server…';
     return switch (readEngineAddress(endpoint.text)) {
-      EngineAddressEmpty() => 'Fill in the server address to start.',
+      // The design's wording for the empty form: it names both things that are
+      // missing, where "fill in the server address" named one and left the
+      // reader to discover the other after they had.
+      EngineAddressEmpty() => 'Add an endpoint and a model id to continue.',
       EngineAddressRejected(:final message) => message,
       EngineAddressReady() => _serverBlockedReason(),
     };
@@ -472,7 +494,10 @@ class ModelField extends StatelessWidget {
   Widget build(BuildContext context) {
     if (suggestedModels.isEmpty) {
       return LabeledField(
-        label: 'Model',
+        // "Model id", not "Model": what goes here is the string the server
+        // answers to, and beside "Shown on the grid as" the difference between
+        // the two names is the whole point of having both.
+        label: 'Model id',
         controller: model,
         hint: 'gemma4-31b.gguf',
       );
@@ -484,7 +509,7 @@ class ModelField extends StatelessWidget {
         // AppSelectField for the same reason as the other two pickers: a
         // Material dropdown's popup can't match the app's floating menus.
         return AppSelectField<String>(
-          label: 'Model',
+          label: 'Model id',
           value: value,
           options: [
             for (final m in suggestedModels)
@@ -493,6 +518,55 @@ class ModelField extends StatelessWidget {
           onChanged: (v) => model.text = v,
         );
       },
+    );
+  }
+}
+
+/// The context window for an *external* server: a picker, not a slider.
+///
+/// The design draws it that way, and the reason survives the drawing. A local
+/// model's window is a choice about memory, which is what a slider is for. A
+/// server's window is a number it was already launched with, so the question is
+/// "which of these did you start it on" — and a list answers that in one press
+/// without a drag that can land a thousand tokens off.
+///
+/// [contextLadder] keeps whatever is already set as its own rung, so opening
+/// this can never round somebody's `--ctx-size` to the nearest familiar number.
+class _ContextSelect extends StatelessWidget {
+  const _ContextSelect({
+    required this.max,
+    required this.value,
+    required this.note,
+    required this.onChanged,
+  });
+
+  final int max;
+  final int value;
+
+  /// What the server said about its own window, when it said anything.
+  final String? note;
+  final ValueChanged<int> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final rungs = contextLadder(max: max, current: value);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        AppSelectField<int>(
+          label: 'Context window',
+          value: rungs.contains(value) ? value : rungs.last,
+          options: [
+            for (final rung in rungs)
+              AppSelectOption(value: rung, label: formatContextLength(rung)),
+          ],
+          onChanged: onChanged,
+        ),
+        if (note case final line?) ...[
+          const SizedBox(height: 6),
+          Text(line, style: ShareType.note),
+        ],
+      ],
     );
   }
 }

--- a/lib/features/provider_node/presentation/external_server_block.dart
+++ b/lib/features/provider_node/presentation/external_server_block.dart
@@ -9,6 +9,7 @@ import '../../../infrastructure/state/models/network_credential.dart';
 import '../../../shared/widgets/advertise_as_field.dart';
 import '../../../shared/widgets/app_select_field.dart';
 import '../../../shared/widgets/context_window_field.dart';
+import '../../../shared/widgets/form_plate.dart';
 import '../../../shared/widgets/labeled_field.dart';
 import '../../../shared/widgets/node_name_field.dart';
 import '../../../core/context_length.dart';
@@ -368,30 +369,44 @@ class ServerForm extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        ServerAddressField(
-          controller: endpoint,
-          checking: checking,
-          reach: reach,
-          onRetry: onRetry,
+        // Five fields in one column read as five steps. Ruled into three
+        // groups they read as what they are: where the engine is, what it is
+        // called, and how much it remembers.
+        FormPlate(
+          sections: [
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                ServerAddressField(
+                  controller: endpoint,
+                  checking: checking,
+                  reach: reach,
+                  onRetry: onRetry,
+                ),
+                const SizedBox(height: 14),
+                ModelField(model: model, suggestedModels: suggestedModels),
+              ],
+            ),
+            FieldPair(
+              first: AdvertiseAsField(
+                controller: advertise,
+                hintText: 'qwen3-31b.gguf',
+                optional: true,
+              ),
+              second: NodeNameField(controller: nodeName),
+            ),
+            ContextWindowField(
+              max: contextMax,
+              value: contextValue,
+              note: contextNote,
+              // Already inside a plate that rules it off from the fields above,
+              // so the recessed tile would be a box inside a box.
+              inline: true,
+              onChanged: onContextChanged,
+            ),
+          ],
         ),
-        const SizedBox(height: 12),
-        ModelField(model: model, suggestedModels: suggestedModels),
-        const SizedBox(height: 12),
-        ContextWindowField(
-          max: contextMax,
-          value: contextValue,
-          note: contextNote,
-          onChanged: onContextChanged,
-        ),
-        const SizedBox(height: 12),
-        AdvertiseAsField(
-          controller: advertise,
-          hintText: 'qwen3-31b.gguf',
-          optional: true,
-        ),
-        const SizedBox(height: 12),
-        NodeNameField(controller: nodeName),
-        const SizedBox(height: 16),
+        const SizedBox(height: 18),
         Align(
           alignment: Alignment.centerLeft,
           child: ListenableBuilder(

--- a/lib/features/provider_node/presentation/external_servers.dart
+++ b/lib/features/provider_node/presentation/external_servers.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../infrastructure/state/models/network_credential.dart';
+import '../../../shared/theme/app_theme.dart';
 import '../../../shared/widgets/app_spinner.dart';
 import '../../models/logic/advertise_name.dart';
 import '../logic/backend_detector.dart';
@@ -60,15 +61,25 @@ class ExternalServers extends ConsumerWidget {
             ),
           const SizedBox(height: 16),
         ],
+        // A rule with its own words, because what follows is not another
+        // detected engine — it is the fallback for an engine Grid could not
+        // find. Without it the manual form reads as a fourth card in the list
+        // and the reader looks for their server in it.
+        if (detected.isNotEmpty) ...[
+          const _OrDivider(),
+          const SizedBox(height: 16),
+        ],
         ExternalServerBlock(
           key: const ValueKey('manual'),
           network: network,
-          collapsible: true,
+          // Open. It used to fold away, which was right while this sat three
+          // disclosures deep on a page of stacked rows; on a pane of its own
+          // it is the route's own form, and a route whose form is shut shows
+          // the reader nothing to do.
+          collapsible: false,
           icon: Icons.computer_outlined,
-          title: 'Connect something else',
-          subtitle:
-              'Point Grid at any OpenAI-compatible engine running on this '
-              'computer.',
+          title: 'Point at another endpoint',
+          subtitle: 'Any OpenAI-compatible engine running on this computer.',
         ),
       ],
     );
@@ -134,6 +145,35 @@ class _NotRunningBackendBlock extends ConsumerWidget {
           ),
         ],
       ),
+    );
+  }
+}
+
+/// The rule between what was found here and what has to be typed in.
+class _OrDivider extends StatelessWidget {
+  const _OrDivider();
+
+  @override
+  Widget build(BuildContext context) {
+    AppTheme.watch(context);
+    final theme = Theme.of(context);
+    return Row(
+      children: [
+        Expanded(child: Divider(height: 1, color: AppPalette.divider)),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12),
+          child: Text(
+            'OR POINT AT ANOTHER ENDPOINT',
+            style: theme.textTheme.labelSmall?.copyWith(
+              fontSize: 10.5,
+              fontWeight: AppFont.semibold,
+              letterSpacing: 1.05,
+              color: AppPalette.textSecondary,
+            ),
+          ),
+        ),
+        Expanded(child: Divider(height: 1, color: AppPalette.divider)),
+      ],
     );
   }
 }

--- a/lib/features/provider_node/presentation/external_servers.dart
+++ b/lib/features/provider_node/presentation/external_servers.dart
@@ -3,12 +3,12 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../infrastructure/state/models/network_credential.dart';
 import '../../../shared/theme/app_theme.dart';
+import '../../../shared/theme/share_page_theme.dart';
 import '../../../shared/widgets/app_spinner.dart';
 import '../../models/logic/advertise_name.dart';
 import '../logic/backend_detector.dart';
 import '../logic/ollama_launch_controller.dart';
 import '../logic/provider_run_controller.dart';
-import 'engine_block.dart';
 import 'engine_notes.dart';
 import 'external_server_block.dart';
 
@@ -72,14 +72,12 @@ class ExternalServers extends ConsumerWidget {
         ExternalServerBlock(
           key: const ValueKey('manual'),
           network: network,
-          // Open. It used to fold away, which was right while this sat three
-          // disclosures deep on a page of stacked rows; on a pane of its own
-          // it is the route's own form, and a route whose form is shut shows
-          // the reader nothing to do.
+          // Open, and bare. It used to fold away behind a header, which was
+          // right while this sat three disclosures deep on a page of stacked
+          // rows. On a pane of its own the rule above already names it and the
+          // first field says the rest — a title and a subtitle here made the
+          // page say "another endpoint" three times in six inches.
           collapsible: false,
-          icon: Icons.computer_outlined,
-          title: 'Point at another endpoint',
-          subtitle: 'Any OpenAI-compatible engine running on this computer.',
         ),
       ],
     );
@@ -106,43 +104,71 @@ class _NotRunningBackendBlock extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    AppTheme.watch(context);
     final theme = Theme.of(context);
     final launch = ref.watch(ollamaLaunchControllerProvider);
     final starting = launch is OllamaLaunchStarting;
-    return EngineBlock(
-      icon: Icons.dns_outlined,
-      title: backend.label,
-      subtitle: 'Installed on this computer, but not running yet',
+    return Container(
+      padding: const EdgeInsets.fromLTRB(18, 16, 18, 16),
+      decoration: BoxDecoration(
+        color: SharePalette.accent.withValues(alpha: 0.045),
+        borderRadius: BorderRadius.circular(ShareMetrics.plateRadius),
+        border: Border.all(color: SharePalette.accent.withValues(alpha: 0.3)),
+      ),
       child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
+          Row(
+            children: [
+              Icon(Icons.dns_outlined, size: 22, color: SharePalette.accent),
+              const SizedBox(width: 13),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      backend.label,
+                      style: ShareType.cardTitle.copyWith(fontSize: 14),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      'Installed on this computer, not running yet.',
+                      style: ShareType.buttonHelper,
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 16),
+              FilledButton.icon(
+                onPressed: starting
+                    ? null
+                    : () => ref
+                          .read(ollamaLaunchControllerProvider.notifier)
+                          .start(),
+                style: FilledButton.styleFrom(
+                  minimumSize: const Size(0, 34),
+                  padding: const EdgeInsets.symmetric(horizontal: 15),
+                  textStyle: const TextStyle(
+                    fontSize: 13,
+                    fontWeight: AppFont.semibold,
+                  ),
+                ),
+                icon: starting
+                    ? const AppSpinner.onAccent()
+                    : const Icon(Icons.play_arrow, size: 16),
+                label: Text(starting ? 'Starting…' : 'Launch & share'),
+              ),
+            ],
+          ),
           if (launch is OllamaLaunchFailed) ...[
+            const SizedBox(height: 12),
             Text(
               launch.message,
               style: theme.textTheme.bodySmall?.copyWith(
                 color: theme.colorScheme.error,
               ),
             ),
-            const SizedBox(height: 12),
           ],
-          Align(
-            alignment: Alignment.centerLeft,
-            child: FilledButton.icon(
-              onPressed: starting
-                  ? null
-                  : () => ref
-                        .read(ollamaLaunchControllerProvider.notifier)
-                        .start(),
-              icon: starting
-                  ? const AppSpinner()
-                  : const Icon(Icons.play_arrow),
-              label: Text(
-                starting
-                    ? 'Starting ${backend.label}…'
-                    : 'Run ${backend.label}',
-              ),
-            ),
-          ),
         ],
       ),
     );

--- a/lib/features/provider_node/presentation/provider_view.dart
+++ b/lib/features/provider_node/presentation/provider_view.dart
@@ -284,7 +284,7 @@ ShareRoute shareRoute(WidgetRef ref) {
   return defaultShareRoute(
     canRunLocal: offers.any((offer) => offer.route == ShareRoute.local),
     serverFound: offers.any(
-      (offer) => offer.route == ShareRoute.server && offer.badge != null,
+      (offer) => offer.route == ShareRoute.server && offer.detected > 0,
     ),
     hasKeyProvider: offers.any((offer) => offer.route == ShareRoute.key),
   );

--- a/lib/features/provider_node/presentation/provider_view.dart
+++ b/lib/features/provider_node/presentation/provider_view.dart
@@ -4,6 +4,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../infrastructure/state/models/network_credential.dart';
 import '../../../shared/layouts/shell_state.dart';
 import '../../../shared/theme/app_theme.dart';
+import '../../../shared/theme/share_page_theme.dart';
+import '../../../shared/widgets/labeled_field.dart';
 import '../../auth/logic/session_controller.dart';
 import '../../models/logic/engine_setup_controller.dart';
 import '../../network/presentation/enable_provider_card.dart';
@@ -65,11 +67,66 @@ class _ProviderViewState extends ConsumerState<ProviderView> {
 class _ShareIntelligencePage extends ConsumerWidget {
   const _ShareIntelligencePage();
 
-  /// Below this the two panes stop being two: a 380px rail beside a form is
-  /// most of a narrow window, and both halves end up too tight to read. Desktop
-  /// windows get dragged small (§4), so the layout has to have an answer.
+  /// Below this the two panes stop being two: the design's 396px rail beside a
+  /// form is most of a narrow window, and both halves end up too tight to read.
+  /// Desktop windows get dragged small (§4), so the layout has to have an
+  /// answer.
   static const double _splitAt = 940;
-  static const double _railWidth = 380;
+
+  /// The mockup's field: a visible 1px rim at radius 9 on a light fill, where
+  /// the app's own idiom is a borderless capsule at radius 12. Hung over the
+  /// page so every field inside it — the model picker, both name boxes, the API
+  /// key, the endpoint — picks the design up without seven widgets each growing
+  /// a parameter for it.
+  static FieldSkin get _fieldSkin => FieldSkin(
+    fill: SharePalette.fieldFill,
+    rim: SharePalette.fieldRim,
+    radius: ShareMetrics.fieldRadius,
+    // 38px tall at 13.5px text, which is the design's field.
+    contentPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+    hintSize: 13.5,
+    labelStyle: ShareType.fieldLabel,
+    showHelp: false,
+  );
+
+  /// The design's buttons and links, for the whole page at once.
+  ///
+  /// Material reads these from the theme, so one override here reaches
+  /// `FilledButton`, `EngineStartButton` and every `TextButton.icon` in the
+  /// forms — including the ones inside widgets this page does not own.
+  ThemeData _pageTheme(BuildContext context) {
+    final theme = Theme.of(context);
+    return theme.copyWith(
+      filledButtonTheme: FilledButtonThemeData(
+        style: FilledButton.styleFrom(
+          backgroundColor: SharePalette.accent,
+          foregroundColor: Colors.white,
+          minimumSize: const Size(0, ShareMetrics.buttonHeight),
+          padding: const EdgeInsets.symmetric(horizontal: 18),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(ShareMetrics.fieldRadius),
+          ),
+          textStyle: const TextStyle(
+            fontSize: 13.5,
+            fontWeight: AppFont.semibold,
+          ),
+          tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+        ),
+      ),
+      textButtonTheme: TextButtonThemeData(
+        style: TextButton.styleFrom(
+          foregroundColor: SharePalette.accent,
+          padding: const EdgeInsets.symmetric(horizontal: 6),
+          minimumSize: const Size(0, 28),
+          textStyle: const TextStyle(
+            fontSize: 12,
+            fontWeight: AppFont.semibold,
+          ),
+          tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+        ),
+      ),
+    );
+  }
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -88,33 +145,42 @@ class _ShareIntelligencePage extends ConsumerWidget {
     // note on `NetworkCredential.isProvider` vs `.role`.
     if (!network.isProvider) return _LockedPage(network: network);
 
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        final rail = _RailPane(network: network);
-        final detail = _DetailPane(network: network);
-        if (constraints.maxWidth < _splitAt) {
-          return SingleChildScrollView(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                // Bounded, because a rail that is a whole scrolling column has
-                // no bottom to pin its footnote to.
-                SizedBox(height: 520, child: rail),
-                Divider(height: 1, color: AppPalette.divider),
-                SizedBox(height: constraints.maxHeight, child: detail),
-              ],
-            ),
-          );
-        }
-        return Row(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            SizedBox(width: _railWidth, child: rail),
-            VerticalDivider(width: 1, color: AppPalette.divider),
-            Expanded(child: detail),
-          ],
-        );
-      },
+    return Theme(
+      data: _pageTheme(context),
+      child: FieldSkinScope(
+        skin: _fieldSkin,
+        child: ColoredBox(
+          color: SharePalette.pageBg,
+          child: LayoutBuilder(
+            builder: (context, constraints) {
+              final rail = _RailPane(network: network);
+              final detail = _DetailPane(network: network);
+              if (constraints.maxWidth < _splitAt) {
+                return SingleChildScrollView(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      // Bounded, because a rail that is a whole scrolling
+                      // column has no bottom to pin its footnote to.
+                      SizedBox(height: 520, child: rail),
+                      Divider(height: 1, color: SharePalette.rim),
+                      SizedBox(height: constraints.maxHeight, child: detail),
+                    ],
+                  ),
+                );
+              }
+              return Row(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  SizedBox(width: ShareMetrics.railWidth, child: rail),
+                  VerticalDivider(width: 1, color: SharePalette.rim),
+                  Expanded(child: detail),
+                ],
+              );
+            },
+          ),
+        ),
+      ),
     );
   }
 }
@@ -130,9 +196,9 @@ class _RailPane extends ConsumerWidget {
     final serving = ref.watch(servingEnginesProvider);
     final run = ref.watch(providerRunControllerProvider);
     return ColoredBox(
-      color: AppPalette.panelBg,
+      color: SharePalette.railBg,
       child: Padding(
-        padding: const EdgeInsets.fromLTRB(24, 26, 24, 22),
+        padding: ShareMetrics.railPadding,
         child: ShareRouteRail(
           network: network,
           offers: shareRouteOffers(ref),
@@ -160,7 +226,7 @@ class _DetailPane extends ConsumerWidget {
     final busy = _startingHere(run, network) || _stoppingHere(run, network);
 
     return Padding(
-      padding: const EdgeInsets.fromLTRB(28, 26, 28, 26),
+      padding: ShareMetrics.panePadding,
       child: switch (run) {
         // Bad news first: a failure is the only thing on this page that the
         // reader cannot act on anywhere else.

--- a/lib/features/provider_node/presentation/provider_view.dart
+++ b/lib/features/provider_node/presentation/provider_view.dart
@@ -87,6 +87,7 @@ class _ShareIntelligencePage extends ConsumerWidget {
     hintSize: 13.5,
     labelStyle: ShareType.fieldLabel,
     showHelp: false,
+    slimChevron: true,
   );
 
   /// The design's buttons and links, for the whole page at once.

--- a/lib/features/provider_node/presentation/provider_view.dart
+++ b/lib/features/provider_node/presentation/provider_view.dart
@@ -1,25 +1,26 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../../shared/theme/app_theme.dart';
-
 import '../../../infrastructure/state/models/network_credential.dart';
 import '../../../shared/layouts/shell_state.dart';
-import '../../../shared/widgets/section_scaffold.dart';
+import '../../../shared/theme/app_theme.dart';
 import '../../auth/logic/session_controller.dart';
-import '../../messaging/presentation/remote_reach_row.dart';
 import '../../models/logic/engine_setup_controller.dart';
 import '../../network/presentation/enable_provider_card.dart';
 import '../../network/presentation/sharing_locked_view.dart';
+import '../../node_setup/logic/auto_host_controller.dart';
+import '../../node_setup/logic/node_capabilities.dart';
+import '../../node_setup/logic/node_setup_plan.dart';
 import '../../node_setup/presentation/node_setup_card.dart';
-import '../logic/engine_slots.dart';
+import '../logic/api_engine_catalog.dart';
 import '../logic/provider_run_controller.dart';
 import '../logic/serving_engines_provider.dart';
-import 'add_engine_options.dart';
+import '../logic/share_route.dart';
+import '../logic/share_route_offer.dart';
 import 'engine_block.dart';
-import 'contribution_summary.dart';
 import 'engine_failure_card.dart';
-import 'serving_engines_section.dart';
+import 'share_route_detail.dart';
+import 'share_route_rail.dart';
 
 /// Provider lifecycle. Enables the provider role when missing, then serves a
 /// model — from a local GGUF (the main flow) or an external OpenAI-compatible
@@ -47,23 +48,232 @@ class _ProviderViewState extends ConsumerState<ProviderView> {
       });
     }
 
-    return SectionScaffold(
-      // The sidebar row's own words — one screen, one name (§5).
-      title: 'Share Intelligence',
-      // Names the grid every sentence on this page is about. It is all that
-      // survives of the scope bar that used to head the body: that block
-      // existed to name *and switch* the grid, and it justified itself by the
-      // Grids tab being developer-only — which stopped being true when Settings
-      // ▸ Grid shipped. The naming is still needed, so it moves into the header
-      // the page already had, as a line rather than a card.
-      subtitle: network == null
-          ? null
-          : 'Put this computer to work on ${network.name}.',
-      // _ServeSection owns its own scrolling: the running engine fills the
-      // height (only its log scrolls), other states scroll as a page.
-      child: const _ServeSection(),
+    return const _ShareIntelligencePage();
+  }
+}
+
+/// Share Intelligence: the three ways in on the left, the one being set up on
+/// the right.
+///
+/// The only section view that does not sit in [SectionScaffold], and the reason
+/// is the rail. That frame draws a page title and a rule across the top, which
+/// is the right shape when a page is one column of content — but here the
+/// heading, the machine's status and the route picker are *one* thing running
+/// down the left, and a second title above them said "Share Intelligence" over
+/// a rail whose own first line already says what the page is for. The top bar
+/// button that opens this page carries the name.
+class _ShareIntelligencePage extends ConsumerWidget {
+  const _ShareIntelligencePage();
+
+  /// Below this the two panes stop being two: a 380px rail beside a form is
+  /// most of a narrow window, and both halves end up too tight to read. Desktop
+  /// windows get dragged small (§4), so the layout has to have an answer.
+  static const double _splitAt = 940;
+  static const double _railWidth = 380;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    AppTheme.watch(context);
+    final network = ref.watch(selectedNetworkProvider);
+    if (network == null) return const _NoGridYet();
+
+    // Sharing on THIS grid is locked (an admin hasn't turned engines on; a
+    // consumer isn't allowed to). Installing the engine still needs no grid
+    // permission, so offer the set-up instead of a wall — then stop here, since
+    // a join would be rejected until sharing is on.
+    //
+    // An admin sees the one-tap fix ([EnableProviderCard] grants itself the
+    // role); everyone else gets [SharingLockedView], which explains what they
+    // *can* do here. The two gates read different axes on purpose — see the
+    // note on `NetworkCredential.isProvider` vs `.role`.
+    if (!network.isProvider) return _LockedPage(network: network);
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final rail = _RailPane(network: network);
+        final detail = _DetailPane(network: network);
+        if (constraints.maxWidth < _splitAt) {
+          return SingleChildScrollView(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                // Bounded, because a rail that is a whole scrolling column has
+                // no bottom to pin its footnote to.
+                SizedBox(height: 520, child: rail),
+                Divider(height: 1, color: AppPalette.divider),
+                SizedBox(height: constraints.maxHeight, child: detail),
+              ],
+            ),
+          );
+        }
+        return Row(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            SizedBox(width: _railWidth, child: rail),
+            VerticalDivider(width: 1, color: AppPalette.divider),
+            Expanded(child: detail),
+          ],
+        );
+      },
     );
   }
+}
+
+/// The rail, with the page's own padding and its slightly recessed ground.
+class _RailPane extends ConsumerWidget {
+  const _RailPane({required this.network});
+
+  final NetworkCredential network;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final serving = ref.watch(servingEnginesProvider);
+    final run = ref.watch(providerRunControllerProvider);
+    return ColoredBox(
+      color: AppPalette.panelBg,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(24, 26, 24, 22),
+        child: ShareRouteRail(
+          network: network,
+          offers: shareRouteOffers(ref),
+          route: shareRoute(ref),
+          live: serving.isNotEmpty,
+          starting: _startingHere(run, network) || _stoppingHere(run, network),
+        ),
+      ),
+    );
+  }
+}
+
+/// The detail pane: whatever this computer's state actually is, in the order
+/// that state has to be read — what broke, what is in the way, what is running,
+/// and only then the route being set up.
+class _DetailPane extends ConsumerWidget {
+  const _DetailPane({required this.network});
+
+  final NetworkCredential network;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final serving = ref.watch(servingEnginesProvider);
+    final run = ref.watch(providerRunControllerProvider);
+    final busy = _startingHere(run, network) || _stoppingHere(run, network);
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(28, 26, 28, 26),
+      child: switch (run) {
+        // Bad news first: a failure is the only thing on this page that the
+        // reader cannot act on anywhere else.
+        ProviderRunFailed(:final message, :final model) => _FailurePane(
+          message: message,
+          engineLabel: model,
+        ),
+        // An engine on ANOTHER grid: remote has one identity per grid, so
+        // starting one here would leave that one. Say so before offering a
+        // form that would do it silently.
+        ProviderRunActive(:final grid) when grid != network.networkId =>
+          _EngineBusyElsewhere(runningGridId: grid),
+        _ when serving.isNotEmpty || busy => LiveShareDetail(network: network),
+        _ => ShareRouteDetail(
+          network: network,
+          offers: shareRouteOffers(ref),
+          route: shareRoute(ref),
+        ),
+      },
+    );
+  }
+}
+
+bool _startingHere(ProviderRunState run, NetworkCredential network) =>
+    run is ProviderRunActive && run.grid == network.networkId && run.starting;
+
+bool _stoppingHere(ProviderRunState run, NetworkCredential network) =>
+    run is ProviderRunStopping && run.grid == network.networkId;
+
+/// The routes this machine can take, read once so the rail and the pane can
+/// never disagree about which route is which number.
+List<ShareRouteOffer> shareRouteOffers(WidgetRef ref) {
+  final caps = ref.watch(nodeCapabilitiesProvider).asData?.value;
+  return buildShareRouteOffers(
+    canRunLocal: ref.watch(supportsBuiltInEngineProvider),
+    needsSetup: caps != null && buildSetupPlan(caps).isNotEmpty,
+    apiEngines: ref.watch(apiEnginesProvider).asData?.value ?? const [],
+    backends: ref.watch(backendsProvider).asData?.value ?? const [],
+  );
+}
+
+/// The route on show: the reader's pick while it is still on offer, else the
+/// default for this machine.
+///
+/// The guard is not theoretical — a key provider disappears when the CLI is
+/// swapped underneath a running app, and a route selected out of a list it is
+/// no longer in would leave the pane showing a form the rail has no card for.
+ShareRoute shareRoute(WidgetRef ref) {
+  final offers = shareRouteOffers(ref);
+  final picked = ref.watch(shareRouteProvider);
+  if (picked != null && offers.any((offer) => offer.route == picked)) {
+    return picked;
+  }
+  return defaultShareRoute(
+    canRunLocal: offers.any((offer) => offer.route == ShareRoute.local),
+    serverFound: offers.any(
+      (offer) => offer.route == ShareRoute.server && offer.badge != null,
+    ),
+    hasKeyProvider: offers.any((offer) => offer.route == ShareRoute.key),
+  );
+}
+
+/// A failure, and the two ways out of it.
+class _FailurePane extends ConsumerWidget {
+  const _FailurePane({required this.message, required this.engineLabel});
+
+  final String message;
+  final String? engineLabel;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) => SingleChildScrollView(
+    child: EngineFailureCard(
+      message: message,
+      engineLabel: engineLabel,
+      // Clears the failed state so the routes come back; the user then starts
+      // from the one they meant to use. We can't replay the exact join here —
+      // the controller doesn't retain its arguments — and guessing which engine
+      // to restart would be worse than asking.
+      onRetry: () =>
+          ref.read(providerRunControllerProvider.notifier).clearFailure(),
+      onReinstallEngine: () =>
+          ref.read(engineSetupControllerProvider.notifier).run(),
+    ),
+  );
+}
+
+/// The page for a grid this user cannot share on.
+class _LockedPage extends StatelessWidget {
+  const _LockedPage({required this.network});
+
+  final NetworkCredential network;
+
+  @override
+  Widget build(BuildContext context) => Padding(
+    padding: const EdgeInsets.all(24),
+    child: SingleChildScrollView(
+      child: network.role == NetworkRole.admin
+          ? Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                EnableProviderCard(network: network),
+                const SizedBox(height: 16),
+                const NodeSetupCard(),
+              ],
+            )
+          // No set-up card here, deliberately. Installing an engine needs no
+          // grid permission, so it *could* be offered — but on a grid you can't
+          // share on, a multi-GB download prepares you for something you still
+          // can't do, and it read as the page's main call to action while the
+          // actual way forward (a grid of your own) sat beside it.
+          : SharingLockedView(network: network),
+    ),
+  );
 }
 
 /// What the page shows with no grid picked — the one state where nothing here
@@ -96,163 +306,6 @@ class _NoGridYet extends ConsumerWidget {
   }
 }
 
-/// The "Share Intelligence" body. A machine serves a *union* of engines on a grid
-/// (ADR 0010), so this is a page, not a single running card: auto-routing at the
-/// top (owner-only), then what's already serving (each engine stoppable on its
-/// own), then the always-available ways to add another engine.
-class _ServeSection extends ConsumerStatefulWidget {
-  const _ServeSection();
-
-  @override
-  ConsumerState<_ServeSection> createState() => _ServeSectionState();
-}
-
-class _ServeSectionState extends ConsumerState<_ServeSection> {
-  @override
-  Widget build(BuildContext context) {
-    final network = ref.watch(selectedNetworkProvider);
-
-    if (network == null) {
-      return const _NoGridYet();
-    }
-    return ListView(children: _children(context, network));
-  }
-
-  List<Widget> _children(BuildContext context, NetworkCredential network) {
-    final run = ref.watch(providerRunControllerProvider);
-    final serving = ref.watch(servingEnginesProvider);
-
-    final children = <Widget>[
-      // What this computer does while nobody is at it. The setup for it lives
-      // on a developer-gated screen, but whether a bot is answering here is not
-      // a developer's fact — it is the machine's.
-      const RemoteReachRow(),
-    ];
-
-    // Sharing on THIS grid is locked (an admin hasn't turned engines on; a
-    // consumer isn't allowed to). Installing the engine still needs no grid
-    // permission, so offer the set-up instead of a wall — then stop here, since
-    // a join would be rejected until sharing is on.
-    //
-    // An admin sees the one-tap fix ([EnableProviderCard] grants itself the
-    // role); everyone else gets [SharingLockedView], which explains what they
-    // *can* do here. The two gates read different axes on purpose — see the note
-    // on `NetworkCredential.isProvider` vs `.role`.
-    if (!network.isProvider) {
-      if (network.role == NetworkRole.admin) {
-        children.addAll([
-          EnableProviderCard(network: network),
-          const SizedBox(height: 16),
-          const NodeSetupCard(),
-          const SizedBox(height: 16),
-        ]);
-      } else {
-        // No set-up card here, deliberately. Installing an engine needs no grid
-        // permission, so it *could* be offered — but on a grid you can't share
-        // on, a multi-GB download prepares you for something you still can't do,
-        // and it read as the page's main call to action while the actual way
-        // forward (a grid of your own) sat beside it. [SharingLockedView] now
-        // carries the single next step instead.
-        children.addAll([
-          SharingLockedView(network: network),
-          const SizedBox(height: 16),
-        ]);
-      }
-      return children;
-    }
-
-    // What this computer is contributing, above everything else: the tab's whole
-    // reason to exist, previously answerable only by reading the entire page.
-    final startingHere =
-        run is ProviderRunActive &&
-        run.grid == network.networkId &&
-        run.starting;
-    // A stop this machine asked for is still running `grid leave`. It keeps the
-    // serving card on screen — the card is what says "Stopping…" — and keeps the
-    // add-engine cards away, so a new join can't race the leave.
-    final stoppingHere =
-        run is ProviderRunStopping && run.grid == network.networkId;
-    children.add(
-      ContributionSummary(
-        engines: serving,
-        gridName: network.name,
-        starting: startingHere,
-      ),
-    );
-
-    // Something broke — it goes directly under the summary, above everything
-    // optional. It used to sit below the auto-routing card, which put a feature
-    // that announces it has nothing to route *between* "you're sharing nothing"
-    // and the reason why. Bad news first, then the offers.
-    if (run is ProviderRunFailed) {
-      children.addAll([
-        EngineFailureCard(
-          message: run.message,
-          engineLabel: run.model,
-          // Clears the failed state so the add forms come back; the user then
-          // starts from the block they meant to use. We can't replay the exact
-          // join here — the controller doesn't retain its arguments — and
-          // guessing which engine to restart would be worse than asking.
-          onRetry: () =>
-              ref.read(providerRunControllerProvider.notifier).clearFailure(),
-          onReinstallEngine: () =>
-              ref.read(engineSetupControllerProvider.notifier).run(),
-        ),
-        const SizedBox(height: 16),
-      ]);
-    }
-
-    // An engine on ANOTHER grid: remote has one identity per grid, so starting
-    // one here leaves that one — warn before the add forms.
-    if (run is ProviderRunActive && run.grid != network.networkId) {
-      children.addAll([
-        _EngineBusyElsewhere(runningGridId: run.grid),
-        const SizedBox(height: 16),
-      ]);
-    }
-
-    // What's already serving on THIS grid (the union), plus a transient row while
-    // a newly-joined engine is still starting.
-    if (serving.isNotEmpty || startingHere || stoppingHere) {
-      children.addAll([
-        ServingEnginesSection(network: network),
-        const SizedBox(height: 16),
-      ]);
-    }
-
-    children.addAll(
-      _addEngineBlocks(network, serving, startingHere || stoppingHere),
-    );
-
-    // Auto-routing used to sit here. It has moved to the grid's own Overview
-    // (Grids tab), because it is a property of the *grid*, not of this computer:
-    // every router command carries `--grid <id>` and none carries a node, so
-    // turning it on here changed how every machine on the grid is routed and
-    // outlived this app being closed. On a page about this computer, where
-    // everything else stops when the machine does, it was the one control that
-    // didn't — and once the add-engine paths became tabs, it had to repeat under
-    // all three, which is what made the mismatch visible.
-    children.add(const SizedBox(height: 16));
-    return children;
-  }
-
-  /// The ways to add an engine — one row each, in the same words the first-run
-  /// screen uses on its cards ([AddEngineOptions]).
-  ///
-  /// A computer shares **one** engine ([canAddEngine]), so the cards only appear
-  /// while nothing is serving. Once something is, the section is simply absent —
-  /// the serving card above is the whole story, and its Stop button is the way
-  /// to a different engine. The same goes while a join or a stop is [busy] on
-  /// the wire: a card pressed now would race the CLI call already running.
-  List<Widget> _addEngineBlocks(
-    NetworkCredential network,
-    List<ServingEngine> serving,
-    bool busy,
-  ) => busy || !canAddEngine(serving)
-      ? const []
-      : [AddEngineOptions(network: network)];
-}
-
 /// Shown when an engine is already serving a *different* grid. Only one engine
 /// runs at a time, so rather than a Start form that would silently stop it, this
 /// names the busy grid and offers a single Stop so the user is in control.
@@ -267,47 +320,49 @@ class _EngineBusyElsewhere extends ConsumerWidget {
     final runningName =
         ref.watch(sessionProvider).byName(runningGridId)?.name ??
         'another grid';
-    return EngineSurface(
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Icon(Icons.dns, color: AppPalette.online, size: 20),
-              const SizedBox(width: 10),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      'An engine is already running on $runningName',
-                      style: theme.textTheme.titleMedium,
-                    ),
-                    const SizedBox(height: 4),
-                    Text(
-                      'You can run an engine on only one grid at a time. Stop '
-                      'it to start one on this grid.',
-                      style: theme.textTheme.bodySmall?.copyWith(
-                        color: theme.colorScheme.onSurfaceVariant,
+    return SingleChildScrollView(
+      child: EngineSurface(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Icon(Icons.dns, color: AppPalette.online, size: 20),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'An engine is already running on $runningName',
+                        style: theme.textTheme.titleMedium,
                       ),
-                    ),
-                  ],
+                      const SizedBox(height: 4),
+                      Text(
+                        'You can run an engine on only one grid at a time. '
+                        'Stop it to start one on this grid.',
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                    ],
+                  ),
                 ),
-              ),
-            ],
-          ),
-          const SizedBox(height: 16),
-          Align(
-            alignment: Alignment.centerLeft,
-            child: FilledButton.icon(
-              onPressed: () =>
-                  ref.read(providerRunControllerProvider.notifier).stop(),
-              icon: const Icon(Icons.stop),
-              label: Text('Stop engine on $runningName'),
+              ],
             ),
-          ),
-        ],
+            const SizedBox(height: 16),
+            Align(
+              alignment: Alignment.centerLeft,
+              child: FilledButton.icon(
+                onPressed: () =>
+                    ref.read(providerRunControllerProvider.notifier).stop(),
+                icon: const Icon(Icons.stop),
+                label: Text('Stop engine on $runningName'),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/features/provider_node/presentation/server_address_field.dart
+++ b/lib/features/provider_node/presentation/server_address_field.dart
@@ -49,7 +49,10 @@ class ServerAddressField extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             LabeledField(
-              label: 'Server address',
+              // The design names the *kind* of thing in the label, because
+              // "server address" tells someone who has one where to put it and
+              // tells someone who hasn't nothing at all.
+              label: 'Endpoint, any OpenAI-compatible server',
               controller: controller,
               // The full endpoint, not the base: it is what people have in
               // front of them, so it can be pasted whole. The suffix is cut

--- a/lib/features/provider_node/presentation/share_route_detail.dart
+++ b/lib/features/provider_node/presentation/share_route_detail.dart
@@ -42,6 +42,20 @@ class ShareRouteDetail extends ConsumerWidget {
   /// row that is not on the page.
   int get _position => offers.indexWhere((offer) => offer.route == route) + 1;
 
+  /// How many engines were detected here, read off the badge the rail already
+  /// draws, so the paragraph and the card can never disagree about the count.
+  int get _serversFound {
+    final server = offers
+        .where((offer) => offer.route == ShareRoute.server)
+        .firstOrNull;
+    final badge = server?.badge;
+    if (badge == null) return 0;
+    return int.tryParse(badge.split(' ').first) ?? 0;
+  }
+
+  String get _foundPhrase =>
+      _serversFound == 1 ? 'one engine' : '$_serversFound engines';
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     AppTheme.watch(context);
@@ -61,10 +75,17 @@ class ShareRouteDetail extends ConsumerWidget {
       ),
       ShareRoute.server => (
         'EXISTING SERVER',
-        'Share what is already running.',
-        'Point Grid at an engine on this computer and your setup is shared '
-            'exactly as you configured it: same models, same quantisation, '
-            'same flags.',
+        "Share what's already running.",
+        // Names the count when there is one to name — the design's sentence —
+        // and falls back to the general one when nothing was detected, where
+        // "Grid found one engine" would be a plain untruth (§5).
+        _serversFound == 0
+            ? 'Point Grid at an engine on this computer and your existing '
+                  'setup is shared exactly as configured: models, '
+                  'quantization, flags.'
+            : 'Grid found $_foundPhrase on this computer. Point at it and '
+                  'your existing setup is shared exactly as configured: '
+                  'models, quantization, flags.',
       ),
     };
 

--- a/lib/features/provider_node/presentation/share_route_detail.dart
+++ b/lib/features/provider_node/presentation/share_route_detail.dart
@@ -42,16 +42,14 @@ class ShareRouteDetail extends ConsumerWidget {
   /// row that is not on the page.
   int get _position => offers.indexWhere((offer) => offer.route == route) + 1;
 
-  /// How many engines were detected here, read off the badge the rail already
-  /// draws, so the paragraph and the card can never disagree about the count.
-  int get _serversFound {
-    final server = offers
-        .where((offer) => offer.route == ShareRoute.server)
-        .firstOrNull;
-    final badge = server?.badge;
-    if (badge == null) return 0;
-    return int.tryParse(badge.split(' ').first) ?? 0;
-  }
+  /// How many engines were detected here, off the same offer the rail draws
+  /// from, so the paragraph and the card can never disagree about the count.
+  int get _serversFound =>
+      offers
+          .where((offer) => offer.route == ShareRoute.server)
+          .firstOrNull
+          ?.detected ??
+      0;
 
   String get _foundPhrase =>
       _serversFound == 1 ? 'one engine' : '$_serversFound engines';

--- a/lib/features/provider_node/presentation/share_route_detail.dart
+++ b/lib/features/provider_node/presentation/share_route_detail.dart
@@ -111,26 +111,22 @@ class ShareRouteDetail extends ConsumerWidget {
   }
 }
 
-/// A pane's content, held to the design's reading width and pinned left.
+/// A pane's content, filling the half of the page it was given.
 ///
-/// Without the cap, a paragraph on a wide display runs the full width of the
-/// window and every form field stretches with it — the two things a measure
-/// exists to stop.
+/// The design holds it to a 720px measure, which is the right call on its own
+/// canvas — that mock has no app sidebar, so 720 *is* most of the pane. Here
+/// the sidebar takes 280 of the window before this page starts, and the same
+/// cap left a plate floating in a field of empty ground on any window wider
+/// than about 1200. The pane's own padding is the measure now.
 class _PaneColumn extends StatelessWidget {
   const _PaneColumn({required this.children});
 
   final List<Widget> children;
 
   @override
-  Widget build(BuildContext context) => Align(
-    alignment: Alignment.topLeft,
-    child: ConstrainedBox(
-      constraints: const BoxConstraints(maxWidth: ShareMetrics.paneMaxWidth),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: children,
-      ),
-    ),
+  Widget build(BuildContext context) => Column(
+    crossAxisAlignment: CrossAxisAlignment.stretch,
+    children: children,
   );
 }
 

--- a/lib/features/provider_node/presentation/share_route_detail.dart
+++ b/lib/features/provider_node/presentation/share_route_detail.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../infrastructure/state/models/network_credential.dart';
 import '../../../shared/theme/app_theme.dart';
+import '../../../shared/theme/share_page_theme.dart';
 import '../../models/presentation/serve_local_card.dart';
 import '../../node_setup/logic/node_capabilities.dart';
 import '../../node_setup/logic/node_setup_controller.dart';
@@ -67,15 +68,14 @@ class ShareRouteDetail extends ConsumerWidget {
       ),
     };
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
+    return _PaneColumn(
       children: [
         PanelHeader(
           eyebrow: 'ROUTE 0$_position · $eyebrow',
           title: title,
           blurb: blurb,
         ),
-        const SizedBox(height: 22),
+        const SizedBox(height: ShareMetrics.paneGap),
         Expanded(
           child: SingleChildScrollView(
             child: switch (route) {
@@ -88,6 +88,29 @@ class ShareRouteDetail extends ConsumerWidget {
       ],
     );
   }
+}
+
+/// A pane's content, held to the design's reading width and pinned left.
+///
+/// Without the cap, a paragraph on a wide display runs the full width of the
+/// window and every form field stretches with it — the two things a measure
+/// exists to stop.
+class _PaneColumn extends StatelessWidget {
+  const _PaneColumn({required this.children});
+
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) => Align(
+    alignment: Alignment.topLeft,
+    child: ConstrainedBox(
+      constraints: const BoxConstraints(maxWidth: ShareMetrics.paneMaxWidth),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: children,
+      ),
+    ),
+  );
 }
 
 /// What the pane is about, before anything it asks for.
@@ -112,32 +135,19 @@ class PanelHeader extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     AppTheme.watch(context);
-    final theme = Theme.of(context);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(
           eyebrow,
-          style: theme.textTheme.labelSmall?.copyWith(
-            fontSize: 10.5,
-            fontWeight: AppFont.semibold,
-            letterSpacing: 1.05,
-            color: eyebrowColour ?? AppPalette.textSecondary,
-          ),
+          style: eyebrowColour == null
+              ? ShareType.eyebrow
+              : ShareType.eyebrow.copyWith(color: eyebrowColour),
         ),
         const SizedBox(height: 7),
-        Text(title, style: theme.textTheme.headlineSmall),
+        Text(title, style: ShareType.paneTitle),
         const SizedBox(height: 7),
-        ConstrainedBox(
-          constraints: const BoxConstraints(maxWidth: 640),
-          child: Text(
-            blurb,
-            style: theme.textTheme.bodyMedium?.copyWith(
-              color: AppPalette.textSecondary,
-              height: 1.55,
-            ),
-          ),
-        ),
+        Text(blurb, style: ShareType.paneBody),
       ],
     );
   }
@@ -196,17 +206,14 @@ class _SetUpFirst extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
+    AppTheme.watch(context);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(
           'This computer needs the built-in engine before it can run a '
           'model. It downloads once and takes a few minutes.',
-          style: theme.textTheme.bodyMedium?.copyWith(
-            color: AppPalette.textSecondary,
-            height: 1.5,
-          ),
+          style: ShareType.paneBody,
         ),
         const SizedBox(height: 16),
         FilledButton.icon(
@@ -270,16 +277,15 @@ class LiveShareDetail extends ConsumerWidget {
       1 => 'Serving ${models.first} on ${network.name}',
       final n => 'Serving $n models on ${network.name}',
     };
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
+    return _PaneColumn(
       children: [
         PanelHeader(
           eyebrow: 'LIVE ON THE GRID',
-          eyebrowColour: AppPalette.online,
+          eyebrowColour: SharePalette.liveInk,
           title: 'This computer is answering questions.',
           blurb: '$what. Leave Grid running and it keeps working.',
         ),
-        const SizedBox(height: 22),
+        const SizedBox(height: ShareMetrics.paneGap),
         Expanded(
           child: SingleChildScrollView(
             child: ServingEnginesSection(network: network),

--- a/lib/features/provider_node/presentation/share_route_detail.dart
+++ b/lib/features/provider_node/presentation/share_route_detail.dart
@@ -1,0 +1,291 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../infrastructure/state/models/network_credential.dart';
+import '../../../shared/theme/app_theme.dart';
+import '../../models/presentation/serve_local_card.dart';
+import '../../node_setup/logic/node_capabilities.dart';
+import '../../node_setup/logic/node_setup_controller.dart';
+import '../../node_setup/logic/node_setup_plan.dart';
+import '../../node_setup/presentation/node_setup_card.dart';
+import '../logic/api_engine_catalog.dart';
+import '../logic/api_engine_choices.dart';
+import '../logic/serving_engines_provider.dart';
+import '../logic/share_route.dart';
+import '../logic/share_route_offer.dart';
+import 'api_engine_block.dart';
+import 'external_servers.dart';
+import 'serving_engines_section.dart';
+
+/// The right half of Share Intelligence: the route picked on the left, said
+/// once at the top and then set up underneath.
+///
+/// One route at a time, which is the whole reason the page split in two. The
+/// forms it shows are the same ones the stacked rows used to open — they were
+/// never the problem; being three-deep inside disclosures was.
+class ShareRouteDetail extends ConsumerWidget {
+  const ShareRouteDetail({
+    super.key,
+    required this.network,
+    required this.offers,
+    required this.route,
+  });
+
+  final NetworkCredential network;
+  final List<ShareRouteOffer> offers;
+  final ShareRoute route;
+
+  /// Which of the offered routes this is, one-based. Read off the rail's own
+  /// list rather than written into the copy: a machine that cannot run a local
+  /// engine has no route 01, and an eyebrow saying otherwise would number a
+  /// row that is not on the page.
+  int get _position => offers.indexWhere((offer) => offer.route == route) + 1;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    AppTheme.watch(context);
+    final (eyebrow, title, blurb) = switch (route) {
+      ShareRoute.local => (
+        'LOCAL MODEL',
+        'Run a model on this computer.',
+        'Questions arrive over the grid, get answered on your hardware, and '
+            'the answer goes back. The weights never leave this disk.',
+      ),
+      ShareRoute.key => (
+        'YOUR OWN KEY',
+        'Lend a key, not a machine.',
+        'Grid forwards questions to the provider you pick, using your key. '
+            'The key stays on this computer, and what it spends is billed to '
+            'your account.',
+      ),
+      ShareRoute.server => (
+        'EXISTING SERVER',
+        'Share what is already running.',
+        'Point Grid at an engine on this computer and your setup is shared '
+            'exactly as you configured it: same models, same quantisation, '
+            'same flags.',
+      ),
+    };
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        PanelHeader(
+          eyebrow: 'ROUTE 0$_position · $eyebrow',
+          title: title,
+          blurb: blurb,
+        ),
+        const SizedBox(height: 22),
+        Expanded(
+          child: SingleChildScrollView(
+            child: switch (route) {
+              ShareRoute.local => _LocalRoute(network: network),
+              ShareRoute.key => _KeyRoute(network: network),
+              ShareRoute.server => ExternalServers(network: network),
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// What the pane is about, before anything it asks for.
+///
+/// Public because the live pane needs the same three lines in the same sizes,
+/// and two headers a screen apart drifting by a point is exactly the kind of
+/// thing nobody sees until the screenshots sit side by side.
+class PanelHeader extends StatelessWidget {
+  const PanelHeader({
+    super.key,
+    required this.eyebrow,
+    required this.title,
+    required this.blurb,
+    this.eyebrowColour,
+  });
+
+  final String eyebrow;
+  final String title;
+  final String blurb;
+  final Color? eyebrowColour;
+
+  @override
+  Widget build(BuildContext context) {
+    AppTheme.watch(context);
+    final theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          eyebrow,
+          style: theme.textTheme.labelSmall?.copyWith(
+            fontSize: 10.5,
+            fontWeight: AppFont.semibold,
+            letterSpacing: 1.05,
+            color: eyebrowColour ?? AppPalette.textSecondary,
+          ),
+        ),
+        const SizedBox(height: 7),
+        Text(title, style: theme.textTheme.headlineSmall),
+        const SizedBox(height: 7),
+        ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 640),
+          child: Text(
+            blurb,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: AppPalette.textSecondary,
+              height: 1.55,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// The local engine: install it first if this machine still needs it, then the
+/// serve form.
+///
+/// The install is not a step the reader chooses — it is what this route costs
+/// on a machine that has never served. So the button says what it is for, and
+/// the progress replaces it in place rather than opening somewhere else.
+class _LocalRoute extends ConsumerStatefulWidget {
+  const _LocalRoute({required this.network});
+
+  final NetworkCredential network;
+
+  @override
+  ConsumerState<_LocalRoute> createState() => _LocalRouteState();
+}
+
+class _LocalRouteState extends ConsumerState<_LocalRoute> {
+  /// Whether the user has asked for the install on this visit. The serve form
+  /// opens behind it, so the moment the download lands they are looking at the
+  /// model picker rather than a finished checklist.
+  bool _setUpAsked = false;
+
+  Future<void> _setUp() async {
+    final caps = await ref.read(nodeCapabilitiesProvider.future);
+    if (!mounted) return;
+    setState(() => _setUpAsked = true);
+    await ref
+        .read(nodeSetupControllerProvider.notifier)
+        .run(buildSetupPlan(caps));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final caps = ref.watch(nodeCapabilitiesProvider).asData?.value;
+    final needsSetup = caps != null && buildSetupPlan(caps).isNotEmpty;
+    final setup = ref.watch(nodeSetupControllerProvider);
+
+    return switch (setup) {
+      NodeSetupRunning() ||
+      NodeSetupFailed() => const NodeSetupCard(framed: false),
+      _ when needsSetup && !_setUpAsked => _SetUpFirst(onPressed: _setUp),
+      _ => ServeLocalCard(network: widget.network),
+    };
+  }
+}
+
+/// The one press this route needs before it can show a form.
+class _SetUpFirst extends StatelessWidget {
+  const _SetUpFirst({required this.onPressed});
+
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'This computer needs the built-in engine before it can run a '
+          'model. It downloads once and takes a few minutes.',
+          style: theme.textTheme.bodyMedium?.copyWith(
+            color: AppPalette.textSecondary,
+            height: 1.5,
+          ),
+        ),
+        const SizedBox(height: 16),
+        FilledButton.icon(
+          onPressed: onPressed,
+          icon: const Icon(Icons.download_outlined),
+          label: const Text('Set up the engine'),
+        ),
+      ],
+    );
+  }
+}
+
+/// The API-key route. The provider list is read here so the form is never
+/// drawn with nothing to offer.
+class _KeyRoute extends ConsumerWidget {
+  const _KeyRoute({required this.network});
+
+  final NetworkCredential network;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final engines = keyEngines(
+      ref.watch(apiEnginesProvider).asData?.value ?? const <ApiEngine>[],
+    );
+    if (engines.isEmpty) return const SizedBox.shrink();
+    return ApiEngineForm(
+      network: network,
+      engines: engines,
+      // The pane above already carries the header and the explanation, so the
+      // form keeps its full detail without repeating either.
+      compact: false,
+    );
+  }
+}
+
+/// What the pane shows once this computer is actually serving.
+///
+/// The stat panel the design drew here — requests, tokens out, uptime, median
+/// latency — is not built: nothing in this app measures any of the four for
+/// *this* machine, and four figures invented to fill a grid is the one thing a
+/// dashboard must never do (§5). What is real sits below instead: the engines,
+/// each stoppable, from [ServingEnginesSection].
+///
+/// TODO(BE): the grid overview *does* carry per-node answered totals
+/// (`answeredTokensMetric` and friends, with a real "unmeasured" state). Making
+/// them this computer's would mean matching `NetworkCredential.nodeId` to an
+/// `OverviewNode`, which nothing in the app does yet.
+class LiveShareDetail extends ConsumerWidget {
+  const LiveShareDetail({super.key, required this.network});
+
+  final NetworkCredential network;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    AppTheme.watch(context);
+    final models = {
+      for (final engine in ref.watch(servingEnginesProvider)) ...engine.models,
+    };
+    final what = switch (models.length) {
+      0 => 'Serving on ${network.name}',
+      1 => 'Serving ${models.first} on ${network.name}',
+      final n => 'Serving $n models on ${network.name}',
+    };
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        PanelHeader(
+          eyebrow: 'LIVE ON THE GRID',
+          eyebrowColour: AppPalette.online,
+          title: 'This computer is answering questions.',
+          blurb: '$what. Leave Grid running and it keeps working.',
+        ),
+        const SizedBox(height: 22),
+        Expanded(
+          child: SingleChildScrollView(
+            child: ServingEnginesSection(network: network),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/provider_node/presentation/share_route_rail.dart
+++ b/lib/features/provider_node/presentation/share_route_rail.dart
@@ -263,11 +263,14 @@ class _PulseDotState extends State<_PulseDot>
   );
 }
 
-/// One route to press: what it is, what it saves you, and one line of how.
+/// One route to press: what it is, and one line of how.
 ///
-/// The badge carries the benefit in two words so the three cards can be
-/// compared down that column alone — "Private", "Instant", "1 found" answer
-/// "which of these suits me" faster than three sentences do.
+/// It wore a two-word benefit badge for a while — "Private", "Instant", "1
+/// found" — on the argument that three cards compare faster down one column of
+/// chips than across three sentences. They went: the sentence under each title
+/// already says the same thing in words the reader does not have to decode, and
+/// three chips down the right edge of a rail is three more things competing
+/// with the one that is selected.
 class _RouteCard extends StatefulWidget {
   const _RouteCard({
     required this.offer,
@@ -350,24 +353,7 @@ class _RouteCardState extends State<_RouteCard> {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Row(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Expanded(
-                            child: Text(
-                              offer.title,
-                              style: ShareType.cardTitle,
-                            ),
-                          ),
-                          if (offer.badge != null) ...[
-                            const SizedBox(width: 8),
-                            _RouteBadge(
-                              label: offer.badge!,
-                              tone: offer.badgeTone,
-                            ),
-                          ],
-                        ],
-                      ),
+                      Text(offer.title, style: ShareType.cardTitle),
                       const SizedBox(height: 3),
                       Text(offer.line, style: ShareType.cardLine),
                     ],
@@ -376,38 +362,6 @@ class _RouteCardState extends State<_RouteCard> {
               ],
             ),
           ),
-        ),
-      ),
-    );
-  }
-}
-
-/// The two-word benefit on a route card.
-///
-/// Its own widget rather than [BadgePill]: that one is a tinted rim at radius 6
-/// for a badge sitting *in* a list of them, and the design's is a filled chip,
-/// radius 5, no border, at 10px — quieter beside a title, which is the point of
-/// it here.
-class _RouteBadge extends StatelessWidget {
-  const _RouteBadge({required this.label, required this.tone});
-
-  final String label;
-  final ShareBadgeTone tone;
-
-  @override
-  Widget build(BuildContext context) {
-    AppTheme.watch(context);
-    final ready = tone == ShareBadgeTone.ready;
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 3),
-      decoration: BoxDecoration(
-        color: ready ? SharePalette.readyBadgeFill : SharePalette.badgeFill,
-        borderRadius: BorderRadius.circular(ShareMetrics.badgeRadius),
-      ),
-      child: Text(
-        label.toUpperCase(),
-        style: ShareType.badge.copyWith(
-          color: ready ? SharePalette.readyBadgeInk : SharePalette.badgeInk,
         ),
       ),
     );

--- a/lib/features/provider_node/presentation/share_route_rail.dart
+++ b/lib/features/provider_node/presentation/share_route_rail.dart
@@ -1,0 +1,403 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../infrastructure/analytics/analytics_events.dart';
+import '../../../infrastructure/analytics/analytics_providers.dart';
+import '../../../infrastructure/state/models/network_credential.dart';
+import '../../../shared/theme/app_theme.dart';
+import '../../../shared/widgets/detail_widgets.dart';
+import '../../../shared/widgets/status_dot.dart';
+import '../../messaging/presentation/remote_reach_row.dart';
+import '../logic/share_route.dart';
+import '../logic/share_route_offer.dart';
+
+/// The left half of Share Intelligence: what this page is for, what this
+/// computer is doing about it right now, and the three ways in.
+///
+/// It is a rail rather than a header because the three routes are a *choice*,
+/// and a choice reads as one when its options sit side by side and stay put.
+/// Stacked disclosures made the reader open an option to find out what it was,
+/// which is the wrong way round: the point of the description on each card is
+/// that it can be compared without opening anything.
+class ShareRouteRail extends ConsumerWidget {
+  const ShareRouteRail({
+    super.key,
+    required this.network,
+    required this.offers,
+    required this.route,
+    required this.live,
+    required this.starting,
+  });
+
+  final NetworkCredential network;
+
+  /// The routes this machine can actually take, already worded from what was
+  /// found on it.
+  final List<ShareRouteOffer> offers;
+
+  /// The route the detail pane is showing.
+  final ShareRoute route;
+
+  /// Something is serving on this grid, so no route can be started until it
+  /// stops. The cards stay on screen and stop responding: removing them would
+  /// take away the only place that says what the alternatives *were*.
+  final bool live;
+  final bool starting;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    AppTheme.watch(context);
+    // Scrolls as one column, with the footnote pushed to the bottom whenever
+    // there is room for it there. Only the card list scrolled at first, which
+    // is what a pinned footnote usually costs: on a short window the last route
+    // was cut through the middle of its own sentence, and a half-drawn card
+    // reads as a broken page rather than as a list that continues.
+    return LayoutBuilder(
+      builder: (context, constraints) => SingleChildScrollView(
+        child: ConstrainedBox(
+          constraints: BoxConstraints(minHeight: constraints.maxHeight),
+          child: IntrinsicHeight(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                _RailHeader(gridName: network.name),
+                const SizedBox(height: 18),
+                _SharingStatus(live: live, starting: starting),
+                // Nothing at all unless a bot is connected. It belongs beside
+                // the sharing status and nowhere else on this page: both answer
+                // "what is this computer doing while nobody is at it".
+                const Padding(
+                  padding: EdgeInsets.only(top: 12),
+                  child: RemoteReachRow(),
+                ),
+                const SizedBox(height: 18),
+                _RailLabel(live ? 'WAYS TO SHARE' : 'CHOOSE A ROUTE'),
+                const SizedBox(height: 10),
+                for (final offer in offers) ...[
+                  _RouteCard(
+                    offer: offer,
+                    selected: !live && offer.route == route,
+                    enabled: !live && !starting,
+                    onPressed: () {
+                      ref
+                          .read(analyticsProvider)
+                          .addEngineOption(offer.route.name);
+                      ref.read(shareRouteProvider.notifier).pick(offer.route);
+                    },
+                  ),
+                  const SizedBox(height: 8),
+                ],
+                const Spacer(),
+                const SizedBox(height: 14),
+                const _RailFootnote(),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// What the page is for, in the reader's terms rather than the product's.
+class _RailHeader extends StatelessWidget {
+  const _RailHeader({required this.gridName});
+
+  final String gridName;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Put this computer to work.',
+          style: theme.textTheme.headlineMedium?.copyWith(height: 1.14),
+        ),
+        const SizedBox(height: 9),
+        Text(
+          // Names the grid, because every sentence on this page is about it,
+          // and says the choice is reversible before it is made — the thing
+          // that stops a first-time reader hunting for the "right" answer.
+          'Answer questions for $gridName using hardware and keys you '
+          'already own. Pick a route below. You can change it any time.',
+          style: theme.textTheme.bodyMedium?.copyWith(
+            color: AppPalette.textSecondary,
+            height: 1.5,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// Whether this computer is reachable from the grid, said plainly.
+///
+/// It reports; it never offers. The Stop button lives with the engine it stops,
+/// in the detail pane, so there is exactly one place to end a session.
+class _SharingStatus extends StatelessWidget {
+  const _SharingStatus({required this.live, required this.starting});
+
+  final bool live;
+  final bool starting;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final (title, note) = switch ((live, starting)) {
+      (true, _) => (
+        'Sharing, live now',
+        'Requests are reaching this computer.',
+      ),
+      (false, true) => (
+        'Starting an engine',
+        'It shows here as soon as it is serving.',
+      ),
+      (false, false) => (
+        'Not sharing yet',
+        'Nothing on this computer is reachable from the grid.',
+      ),
+    };
+    return Container(
+      padding: const EdgeInsets.fromLTRB(14, 12, 14, 13),
+      decoration: BoxDecoration(
+        color: AppGlass.surfaceFill,
+        borderRadius: BorderRadius.circular(AppCard.radius),
+        border: Border.all(color: AppPalette.divider),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.only(top: 3),
+            child: StatusDot(
+              color: live ? AppPalette.online : AppPalette.textFaint,
+              size: 8,
+              // Breathing only while something is actually happening — a halo
+              // on an idle machine reports activity there isn't any of.
+              pulsing: live || starting,
+            ),
+          ),
+          const SizedBox(width: 11),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    fontWeight: AppFont.semibold,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  note,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: AppPalette.textSecondary,
+                    height: 1.45,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// The small capitalised label over a group in the rail.
+class _RailLabel extends StatelessWidget {
+  const _RailLabel(this.text);
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) => Text(
+    text,
+    style: Theme.of(context).textTheme.labelSmall?.copyWith(
+      fontSize: 10.5,
+      fontWeight: AppFont.semibold,
+      letterSpacing: 1.05,
+      color: AppPalette.textSecondary,
+    ),
+  );
+}
+
+/// One route to press: what it is, what it saves you, and one line of how.
+///
+/// The badge carries the benefit in two words so the three cards can be
+/// compared down that column alone — "Private", "Instant", "1 found" answer
+/// "which of these suits me" faster than three sentences do.
+class _RouteCard extends StatefulWidget {
+  const _RouteCard({
+    required this.offer,
+    required this.selected,
+    required this.enabled,
+    required this.onPressed,
+  });
+
+  final ShareRouteOffer offer;
+  final bool selected;
+  final bool enabled;
+  final VoidCallback onPressed;
+
+  @override
+  State<_RouteCard> createState() => _RouteCardState();
+}
+
+class _RouteCardState extends State<_RouteCard> {
+  bool _hovered = false;
+
+  @override
+  Widget build(BuildContext context) {
+    AppTheme.watch(context);
+    final theme = Theme.of(context);
+    final offer = widget.offer;
+    final selected = widget.selected;
+    final ink = widget.enabled
+        ? AppPalette.textPrimary
+        : AppPalette.textSecondary;
+
+    return Opacity(
+      // Dimmed rather than removed while an engine serves: the cards are the
+      // only place that says what the other two routes were, and a reader who
+      // presses Stop should find the page where they left it.
+      opacity: widget.enabled ? 1 : 0.55,
+      child: MouseRegion(
+        cursor: widget.enabled
+            ? SystemMouseCursors.click
+            : SystemMouseCursors.basic,
+        onEnter: (_) => setState(() => _hovered = true),
+        onExit: (_) => setState(() => _hovered = false),
+        child: GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: widget.enabled ? widget.onPressed : null,
+          child: AnimatedContainer(
+            duration: AppMotion.hover,
+            curve: AppMotion.curve,
+            padding: const EdgeInsets.all(14),
+            decoration: BoxDecoration(
+              color: AppGlass.surfaceFill,
+              borderRadius: BorderRadius.circular(AppCard.radius),
+              border: Border.all(
+                color: selected
+                    ? AppPalette.accent
+                    : _hovered && widget.enabled
+                    ? AppPalette.textFaint
+                    : AppPalette.divider,
+              ),
+              // A ring, not a heavier border: the selected card has to be
+              // findable at a glance without the row growing by a pixel and
+              // shifting the two under it.
+              boxShadow: selected
+                  ? [
+                      BoxShadow(
+                        color: AppPalette.accent.withValues(alpha: 0.14),
+                        spreadRadius: 3,
+                      ),
+                    ]
+                  : AppGlass.cardShadow,
+            ),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Padding(
+                  padding: const EdgeInsets.only(top: 1),
+                  child: Icon(
+                    _routeIcon(offer.route),
+                    size: 21,
+                    color: selected ? AppPalette.accent : AppPalette.textFaint,
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        children: [
+                          Expanded(
+                            child: Text(
+                              offer.title,
+                              style: theme.textTheme.titleSmall?.copyWith(
+                                color: ink,
+                              ),
+                            ),
+                          ),
+                          if (offer.badge != null) ...[
+                            const SizedBox(width: 8),
+                            BadgePill(
+                              label: offer.badge!,
+                              color: _badgeColour(offer.badgeTone),
+                              compact: true,
+                            ),
+                          ],
+                        ],
+                      ),
+                      const SizedBox(height: 3),
+                      Text(
+                        offer.line,
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: AppPalette.textSecondary,
+                          height: 1.45,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// The glyph for a route. Kept beside the card that draws it: [ShareRouteOffer]
+/// is what the machine has to offer, and an [IconData] in it would put Material
+/// in a logic file for the sake of three constants.
+IconData _routeIcon(ShareRoute route) => switch (route) {
+  ShareRoute.local => Icons.computer_outlined,
+  ShareRoute.key => Icons.key_outlined,
+  ShareRoute.server => Icons.dns_outlined,
+};
+
+/// One badge on this page gets a colour: a server already running here, which
+/// is the route that is one press from done. The rest stay neutral, because a
+/// rail where every pill is bright has nothing left to point with.
+Color _badgeColour(ShareBadgeTone tone) => switch (tone) {
+  ShareBadgeTone.neutral => AppPalette.textSecondary,
+  ShareBadgeTone.ready => AppPalette.online,
+};
+
+/// The two facts a host should have before they start, not after.
+class _RailFootnote extends StatelessWidget {
+  const _RailFootnote();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Divider(height: 1, color: AppPalette.divider),
+        const SizedBox(height: 14),
+        Text(
+          // "Keys stay in your keychain" is what the design said here, and this
+          // app has no keychain — a key goes to the local `grid` CLI. The
+          // promise the app can actually keep is the one the API form already
+          // makes, in its words (§5).
+          'Sharing stops the moment you close the lid, quit Grid, or press '
+          'stop. A key you paste never leaves this computer.',
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: AppPalette.textSecondary,
+            height: 1.5,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/provider_node/presentation/share_route_rail.dart
+++ b/lib/features/provider_node/presentation/share_route_rail.dart
@@ -4,7 +4,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../infrastructure/analytics/analytics_events.dart';
 import '../../../infrastructure/analytics/analytics_providers.dart';
 import '../../../infrastructure/state/models/network_credential.dart';
-import '../../../shared/layouts/shell_state.dart';
 import '../../../shared/theme/app_theme.dart';
 import '../../../shared/theme/share_page_theme.dart';
 import '../../messaging/presentation/remote_reach_row.dart';
@@ -424,13 +423,12 @@ IconData _routeIcon(ShareRoute route) => switch (route) {
   ShareRoute.server => Icons.dns_outlined,
 };
 
-/// The two facts a host should have before they start, not after, and the way
-/// to the longer answer.
-class _RailFootnote extends ConsumerWidget {
+/// The two facts a host should have before they start, not after.
+class _RailFootnote extends StatelessWidget {
   const _RailFootnote();
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
     AppTheme.watch(context);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -445,25 +443,6 @@ class _RailFootnote extends ConsumerWidget {
           'Sharing stops the moment you close the lid, quit Grid, or press '
           'stop. A key you paste never leaves this computer.',
           style: ShareType.footnote,
-        ),
-        const SizedBox(height: 7),
-        // Opens the app's own guide. The design's link had no destination and
-        // this one is checked: [ShellSection.guide] is a shipped row, not a
-        // place named on faith (§5).
-        GestureDetector(
-          onTap: () => ref
-              .read(shellSectionProvider.notifier)
-              .select(ShellSection.guide),
-          child: MouseRegion(
-            cursor: SystemMouseCursors.click,
-            child: Text(
-              'How sharing works →',
-              style: ShareType.footnote.copyWith(
-                fontWeight: AppFont.semibold,
-                color: SharePalette.accent,
-              ),
-            ),
-          ),
         ),
       ],
     );

--- a/lib/features/provider_node/presentation/share_route_rail.dart
+++ b/lib/features/provider_node/presentation/share_route_rail.dart
@@ -4,9 +4,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../infrastructure/analytics/analytics_events.dart';
 import '../../../infrastructure/analytics/analytics_providers.dart';
 import '../../../infrastructure/state/models/network_credential.dart';
+import '../../../shared/layouts/shell_state.dart';
 import '../../../shared/theme/app_theme.dart';
-import '../../../shared/widgets/detail_widgets.dart';
-import '../../../shared/widgets/status_dot.dart';
+import '../../../shared/theme/share_page_theme.dart';
 import '../../messaging/presentation/remote_reach_row.dart';
 import '../logic/share_route.dart';
 import '../logic/share_route_offer.dart';
@@ -61,7 +61,7 @@ class ShareRouteRail extends ConsumerWidget {
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
                 _RailHeader(gridName: network.name),
-                const SizedBox(height: 18),
+                const SizedBox(height: ShareMetrics.railGap),
                 _SharingStatus(live: live, starting: starting),
                 // Nothing at all unless a bot is connected. It belongs beside
                 // the sharing status and nowhere else on this page: both answer
@@ -70,9 +70,12 @@ class ShareRouteRail extends ConsumerWidget {
                   padding: EdgeInsets.only(top: 12),
                   child: RemoteReachRow(),
                 ),
-                const SizedBox(height: 18),
-                _RailLabel(live ? 'WAYS TO SHARE' : 'CHOOSE A ROUTE'),
-                const SizedBox(height: 10),
+                const SizedBox(height: ShareMetrics.railGap),
+                Text(
+                  live ? 'WAYS TO SHARE' : 'CHOOSE A ROUTE',
+                  style: ShareType.eyebrow,
+                ),
+                const SizedBox(height: 8),
                 for (final offer in offers) ...[
                   _RouteCard(
                     offer: offer,
@@ -88,7 +91,7 @@ class ShareRouteRail extends ConsumerWidget {
                   const SizedBox(height: 8),
                 ],
                 const Spacer(),
-                const SizedBox(height: 14),
+                const SizedBox(height: 18),
                 const _RailFootnote(),
               ],
             ),
@@ -106,30 +109,27 @@ class _RailHeader extends StatelessWidget {
   final String gridName;
 
   @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(
-          'Put this computer to work.',
-          style: theme.textTheme.headlineMedium?.copyWith(height: 1.14),
-        ),
-        const SizedBox(height: 9),
-        Text(
-          // Names the grid, because every sentence on this page is about it,
-          // and says the choice is reversible before it is made — the thing
-          // that stops a first-time reader hunting for the "right" answer.
-          'Answer questions for $gridName using hardware and keys you '
-          'already own. Pick a route below. You can change it any time.',
-          style: theme.textTheme.bodyMedium?.copyWith(
-            color: AppPalette.textSecondary,
-            height: 1.5,
-          ),
-        ),
-      ],
-    );
-  }
+  Widget build(BuildContext context) => Column(
+    crossAxisAlignment: CrossAxisAlignment.start,
+    children: [
+      Text(
+        // Broken where the design breaks it, not where the rail happens to run
+        // out: "Put this computer" over "to work." is the shape that was drawn,
+        // and it survives a font this app does not ship.
+        'Put this computer\nto work.',
+        style: ShareType.railTitle,
+      ),
+      const SizedBox(height: 9),
+      Text(
+        // Names the grid, because every sentence on this page is about it, and
+        // says the choice is reversible before it is made — the thing that
+        // stops a first-time reader hunting for the "right" answer.
+        'Answer questions for $gridName using hardware and keys you '
+        'already own. Pick a route below. You can change it any time.',
+        style: ShareType.railBody,
+      ),
+    ],
+  );
 }
 
 /// Whether this computer is reachable from the grid, said plainly.
@@ -144,7 +144,7 @@ class _SharingStatus extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
+    AppTheme.watch(context);
     final (title, note) = switch ((live, starting)) {
       (true, _) => (
         'Sharing, live now',
@@ -160,44 +160,29 @@ class _SharingStatus extends StatelessWidget {
       ),
     };
     return Container(
-      padding: const EdgeInsets.fromLTRB(14, 12, 14, 13),
+      padding: const EdgeInsets.fromLTRB(14, 12, 14, 12),
       decoration: BoxDecoration(
-        color: AppGlass.surfaceFill,
-        borderRadius: BorderRadius.circular(AppCard.radius),
-        border: Border.all(color: AppPalette.divider),
+        color: SharePalette.surface,
+        borderRadius: BorderRadius.circular(ShareMetrics.statusRadius),
+        border: Border.all(color: SharePalette.rim),
       ),
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Padding(
-            padding: const EdgeInsets.only(top: 3),
-            child: StatusDot(
-              color: live ? AppPalette.online : AppPalette.textFaint,
-              size: 8,
-              // Breathing only while something is actually happening — a halo
-              // on an idle machine reports activity there isn't any of.
-              pulsing: live || starting,
-            ),
+          // Breathing only while something is actually happening — a halo on an
+          // idle machine reports activity there isn't any of.
+          _PulseDot(
+            colour: live ? SharePalette.liveDot : SharePalette.idleDot,
+            pulsing: live || starting,
           ),
-          const SizedBox(width: 11),
+          const SizedBox(width: 10),
           Expanded(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text(
-                  title,
-                  style: theme.textTheme.bodyMedium?.copyWith(
-                    fontWeight: AppFont.semibold,
-                  ),
-                ),
+                Text(title, style: ShareType.statusTitle),
                 const SizedBox(height: 2),
-                Text(
-                  note,
-                  style: theme.textTheme.bodySmall?.copyWith(
-                    color: AppPalette.textSecondary,
-                    height: 1.45,
-                  ),
-                ),
+                Text(note, style: ShareType.note),
               ],
             ),
           ),
@@ -207,20 +192,74 @@ class _SharingStatus extends StatelessWidget {
   }
 }
 
-/// The small capitalised label over a group in the rail.
-class _RailLabel extends StatelessWidget {
-  const _RailLabel(this.text);
+/// The 7px dot beside the sharing status, breathing while something is live.
+///
+/// Not [StatusDot]: that one is 9px with a glow behind it, drawn for a row in a
+/// list. The design's is a plain 7px circle that pulses by fading and shrinking
+/// on a 2.4s ease — a slower, smaller signal, sized for a block of text rather
+/// than a table.
+class _PulseDot extends StatefulWidget {
+  const _PulseDot({required this.colour, required this.pulsing});
 
-  final String text;
+  final Color colour;
+  final bool pulsing;
 
   @override
-  Widget build(BuildContext context) => Text(
-    text,
-    style: Theme.of(context).textTheme.labelSmall?.copyWith(
-      fontSize: 10.5,
-      fontWeight: AppFont.semibold,
-      letterSpacing: 1.05,
-      color: AppPalette.textSecondary,
+  State<_PulseDot> createState() => _PulseDotState();
+}
+
+class _PulseDotState extends State<_PulseDot>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _beat = AnimationController(
+    vsync: this,
+    duration: const Duration(milliseconds: 2400),
+  );
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    // Reduce Motion gets the dot, not the breathing: the colour already carries
+    // the whole message (§11).
+    final still = !widget.pulsing || MediaQuery.of(context).disableAnimations;
+    if (still) {
+      _beat.stop();
+      _beat.value = 0;
+      return;
+    }
+    if (!_beat.isAnimating) _beat.repeat();
+  }
+
+  @override
+  void didUpdateWidget(_PulseDot oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.pulsing != widget.pulsing) didChangeDependencies();
+  }
+
+  @override
+  void dispose() {
+    _beat.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => Padding(
+    padding: const EdgeInsets.only(top: 4),
+    child: AnimatedBuilder(
+      animation: _beat,
+      builder: (context, child) {
+        // 0 → 1 → 0 over the turn, which is the CSS keyframe's shape: full at
+        // both ends, weakest in the middle.
+        final swing = (0.5 - (_beat.value - 0.5).abs()) * 2;
+        return Opacity(
+          opacity: 1 - 0.65 * swing,
+          child: Transform.scale(scale: 1 - 0.15 * swing, child: child),
+        );
+      },
+      child: Container(
+        width: 7,
+        height: 7,
+        decoration: BoxDecoration(color: widget.colour, shape: BoxShape.circle),
+      ),
     ),
   );
 }
@@ -253,12 +292,8 @@ class _RouteCardState extends State<_RouteCard> {
   @override
   Widget build(BuildContext context) {
     AppTheme.watch(context);
-    final theme = Theme.of(context);
     final offer = widget.offer;
     final selected = widget.selected;
-    final ink = widget.enabled
-        ? AppPalette.textPrimary
-        : AppPalette.textSecondary;
 
     return Opacity(
       // Dimmed rather than removed while an engine serves: the cards are the
@@ -279,36 +314,36 @@ class _RouteCardState extends State<_RouteCard> {
             curve: AppMotion.curve,
             padding: const EdgeInsets.all(14),
             decoration: BoxDecoration(
-              color: AppGlass.surfaceFill,
-              borderRadius: BorderRadius.circular(AppCard.radius),
+              color: SharePalette.surface,
+              borderRadius: BorderRadius.circular(ShareMetrics.cardRadius),
               border: Border.all(
                 color: selected
-                    ? AppPalette.accent
+                    ? SharePalette.accent
                     : _hovered && widget.enabled
-                    ? AppPalette.textFaint
-                    : AppPalette.divider,
+                    ? SharePalette.fieldRim
+                    : SharePalette.rim,
               ),
               // A ring, not a heavier border: the selected card has to be
               // findable at a glance without the row growing by a pixel and
               // shifting the two under it.
               boxShadow: selected
-                  ? [
-                      BoxShadow(
-                        color: AppPalette.accent.withValues(alpha: 0.14),
-                        spreadRadius: 3,
-                      ),
-                    ]
-                  : AppGlass.cardShadow,
+                  ? [BoxShadow(color: SharePalette.accentRing, spreadRadius: 3)]
+                  : null,
             ),
             child: Row(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Padding(
-                  padding: const EdgeInsets.only(top: 1),
-                  child: Icon(
-                    _routeIcon(offer.route),
-                    size: 21,
-                    color: selected ? AppPalette.accent : AppPalette.textFaint,
+                // A fixed gutter, so the three titles start on one line however
+                // wide their glyphs are.
+                SizedBox(
+                  width: 26,
+                  child: Padding(
+                    padding: const EdgeInsets.only(top: 1),
+                    child: Icon(
+                      _routeIcon(offer.route),
+                      size: 22,
+                      color: selected ? SharePalette.accent : SharePalette.line,
+                    ),
                   ),
                 ),
                 const SizedBox(width: 12),
@@ -317,39 +352,63 @@ class _RouteCardState extends State<_RouteCard> {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       Row(
+                        crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
                           Expanded(
                             child: Text(
                               offer.title,
-                              style: theme.textTheme.titleSmall?.copyWith(
-                                color: ink,
-                              ),
+                              style: ShareType.cardTitle,
                             ),
                           ),
                           if (offer.badge != null) ...[
                             const SizedBox(width: 8),
-                            BadgePill(
+                            _RouteBadge(
                               label: offer.badge!,
-                              color: _badgeColour(offer.badgeTone),
-                              compact: true,
+                              tone: offer.badgeTone,
                             ),
                           ],
                         ],
                       ),
                       const SizedBox(height: 3),
-                      Text(
-                        offer.line,
-                        style: theme.textTheme.bodySmall?.copyWith(
-                          color: AppPalette.textSecondary,
-                          height: 1.45,
-                        ),
-                      ),
+                      Text(offer.line, style: ShareType.cardLine),
                     ],
                   ),
                 ),
               ],
             ),
           ),
+        ),
+      ),
+    );
+  }
+}
+
+/// The two-word benefit on a route card.
+///
+/// Its own widget rather than [BadgePill]: that one is a tinted rim at radius 6
+/// for a badge sitting *in* a list of them, and the design's is a filled chip,
+/// radius 5, no border, at 10px — quieter beside a title, which is the point of
+/// it here.
+class _RouteBadge extends StatelessWidget {
+  const _RouteBadge({required this.label, required this.tone});
+
+  final String label;
+  final ShareBadgeTone tone;
+
+  @override
+  Widget build(BuildContext context) {
+    AppTheme.watch(context);
+    final ready = tone == ShareBadgeTone.ready;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 3),
+      decoration: BoxDecoration(
+        color: ready ? SharePalette.readyBadgeFill : SharePalette.badgeFill,
+        borderRadius: BorderRadius.circular(ShareMetrics.badgeRadius),
+      ),
+      child: Text(
+        label.toUpperCase(),
+        style: ShareType.badge.copyWith(
+          color: ready ? SharePalette.readyBadgeInk : SharePalette.badgeInk,
         ),
       ),
     );
@@ -365,26 +424,19 @@ IconData _routeIcon(ShareRoute route) => switch (route) {
   ShareRoute.server => Icons.dns_outlined,
 };
 
-/// One badge on this page gets a colour: a server already running here, which
-/// is the route that is one press from done. The rest stay neutral, because a
-/// rail where every pill is bright has nothing left to point with.
-Color _badgeColour(ShareBadgeTone tone) => switch (tone) {
-  ShareBadgeTone.neutral => AppPalette.textSecondary,
-  ShareBadgeTone.ready => AppPalette.online,
-};
-
-/// The two facts a host should have before they start, not after.
-class _RailFootnote extends StatelessWidget {
+/// The two facts a host should have before they start, not after, and the way
+/// to the longer answer.
+class _RailFootnote extends ConsumerWidget {
   const _RailFootnote();
 
   @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
+  Widget build(BuildContext context, WidgetRef ref) {
+    AppTheme.watch(context);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Divider(height: 1, color: AppPalette.divider),
-        const SizedBox(height: 14),
+        Divider(height: 1, thickness: 1, color: SharePalette.footRule),
+        const SizedBox(height: 18),
         Text(
           // "Keys stay in your keychain" is what the design said here, and this
           // app has no keychain — a key goes to the local `grid` CLI. The
@@ -392,9 +444,25 @@ class _RailFootnote extends StatelessWidget {
           // makes, in its words (§5).
           'Sharing stops the moment you close the lid, quit Grid, or press '
           'stop. A key you paste never leaves this computer.',
-          style: theme.textTheme.bodySmall?.copyWith(
-            color: AppPalette.textSecondary,
-            height: 1.5,
+          style: ShareType.footnote,
+        ),
+        const SizedBox(height: 7),
+        // Opens the app's own guide. The design's link had no destination and
+        // this one is checked: [ShellSection.guide] is a shipped row, not a
+        // place named on faith (§5).
+        GestureDetector(
+          onTap: () => ref
+              .read(shellSectionProvider.notifier)
+              .select(ShellSection.guide),
+          child: MouseRegion(
+            cursor: SystemMouseCursors.click,
+            child: Text(
+              'How sharing works →',
+              style: ShareType.footnote.copyWith(
+                fontWeight: AppFont.semibold,
+                color: SharePalette.accent,
+              ),
+            ),
           ),
         ),
       ],

--- a/lib/shared/theme/share_page_theme.dart
+++ b/lib/shared/theme/share_page_theme.dart
@@ -220,10 +220,6 @@ abstract final class ShareMetrics {
   static const EdgeInsets railPadding = EdgeInsets.fromLTRB(28, 34, 28, 28);
   static const EdgeInsets panePadding = EdgeInsets.fromLTRB(40, 34, 40, 40);
 
-  /// The design holds a pane's prose and forms to this, so a wide window gives
-  /// the reader a column rather than a stretched line.
-  static const double paneMaxWidth = 720;
-
   /// Between the rail's blocks, and between a pane's.
   static const double railGap = 26;
   static const double paneGap = 24;

--- a/lib/shared/theme/share_page_theme.dart
+++ b/lib/shared/theme/share_page_theme.dart
@@ -115,16 +115,10 @@ abstract final class SharePalette {
   static Color get idleDot =>
       AppTheme.pick(const Color(0xFFA8AEBB), const Color(0xFF6E6E6E));
 
-  /// A route card's badge. The green pair is worn by one badge on the page —
-  /// the server already running here.
+  /// A quiet chip: today the context window's value. It was the route cards'
+  /// benefit badge too, until those went.
   static Color get badgeFill =>
       AppTheme.pick(const Color(0xFFEDF0F6), const Color(0xFF2A2A2A));
-  static Color get badgeInk =>
-      AppTheme.pick(const Color(0xFF5F636C), const Color(0xFFB4B4B0));
-  static Color get readyBadgeFill =>
-      AppTheme.pick(const Color(0xFFD2F6DD), const Color(0xFF15321F));
-  static Color get readyBadgeInk =>
-      AppTheme.pick(const Color(0xFF006436), const Color(0xFF6FD68F));
 }
 
 /// The mockup's type scale, by the role each size plays rather than by number.

--- a/lib/shared/theme/share_page_theme.dart
+++ b/lib/shared/theme/share_page_theme.dart
@@ -1,0 +1,244 @@
+import 'package:flutter/material.dart';
+
+import 'app_theme.dart';
+
+/// The Share Intelligence mockup's own palette and type, to the value.
+///
+/// A second palette in one app is a drift risk (§5), and this one is here on
+/// purpose: the design for that page is a *cooler* family than [AppPalette] —
+/// blue-grey inks at hue 265 where the app runs warm at `#62615B`, a deeper
+/// accent, and hairlines several shades darker than the app's 6% black, which
+/// on white is nearly invisible. Matching it by nudging [AppPalette] would
+/// restyle every screen in the app; matching it here restyles the page that was
+/// designed.
+///
+/// **TODO(BE): four of these inks are under §11's 4.5:1 floor**, measured on
+/// this page's own two grounds (`#F9FAFB` rail / `#FDFDFF` card):
+///
+/// ```
+///   line    #74777F   4.29 / 4.41    route card description, 12.3px
+///   note    #777A82   4.11 / 4.23    status note, field helper, 12px
+///   helper  #7D8088   3.78 / 3.89    footnote and button helper, 11.5–12.5px
+///   eyebrow #83868E   3.49 / 3.59    CHOOSE A ROUTE, ROUTE 01, 10.5px
+/// ```
+///
+/// They are the mockup's values and they ship because the mockup is the brief.
+/// The floor is not negotiable long-term: darkening each by roughly one step
+/// (0.55/0.55/0.55/0.5 lightness) clears it and is invisible beside the
+/// original. Decide it, don't inherit it.
+///
+/// Dark values are *derived*, not designed — the mockup is light-only. Each one
+/// answers "what plays this role on a dark ground", taken from [AppPalette] so
+/// the page stays coherent in a theme the design never covered.
+abstract final class SharePalette {
+  /// The ground the whole page sits on.
+  static Color get pageBg =>
+      AppTheme.pick(const Color(0xFFF6F7F9), const Color(0xFF181818));
+
+  /// The rail, a shade above the page so the split reads without a heavy rule.
+  static Color get railBg =>
+      AppTheme.pick(const Color(0xFFF9FAFB), const Color(0xFF141414));
+
+  /// Cards, plates and the status block.
+  static Color get surface =>
+      AppTheme.pick(const Color(0xFFFDFDFF), const Color(0xFF1E1E1E));
+
+  /// The hairline round a card and down the middle of the page.
+  static Color get rim =>
+      AppTheme.pick(const Color(0xFFE1E3E6), const Color(0xFF2E2E2E));
+
+  /// The rule *inside* a plate, one shade lighter than its own rim.
+  static Color get innerRule =>
+      AppTheme.pick(const Color(0xFFE8E9ED), const Color(0xFF282828));
+
+  /// The rule above the rail's footnote.
+  static Color get footRule =>
+      AppTheme.pick(const Color(0xFFE4E6EA), const Color(0xFF2A2A2A));
+
+  /// The unfilled half of a slider's track. A shade under [rim]: the track is
+  /// a surface the thumb runs over, not an edge round a card.
+  static Color get track =>
+      AppTheme.pick(const Color(0xFFE0E1E5), const Color(0xFF313131));
+
+  /// A field's own rim and fill — visible at rest, unlike the app's borderless
+  /// capsule.
+  static Color get fieldRim =>
+      AppTheme.pick(const Color(0xFFDCDEE1), const Color(0xFF343434));
+  static Color get fieldFill =>
+      AppTheme.pick(const Color(0xFFF9FAFB), const Color(0xFF262626));
+
+  /// Headings and anything the reader is meant to read first.
+  static Color get ink =>
+      AppTheme.pick(const Color(0xFF1C1F25), const Color(0xFFF5F5F5));
+
+  /// A field's label.
+  static Color get labelInk =>
+      AppTheme.pick(const Color(0xFF4A4D54), const Color(0xFFC9C9C9));
+
+  /// Body copy: the rail's subtitle, a pane's paragraph.
+  static Color get body =>
+      AppTheme.pick(const Color(0xFF6E7279), const Color(0xFFA8A8A2));
+
+  /// A route card's description.
+  static Color get line =>
+      AppTheme.pick(const Color(0xFF74777F), const Color(0xFF9E9E9A));
+
+  /// A note under a control, and the sharing status' second line.
+  static Color get note =>
+      AppTheme.pick(const Color(0xFF777A82), const Color(0xFF9A9A96));
+
+  /// The quiet line beside a button, and the rail's footnote.
+  static Color get helper =>
+      AppTheme.pick(const Color(0xFF7D8088), const Color(0xFF949490));
+
+  /// Capitalised section labels, and a slider's end marks.
+  static Color get eyebrow =>
+      AppTheme.pick(const Color(0xFF83868E), const Color(0xFF8C8C88));
+
+  /// The one blue on the page: a selected route, a link, the button that
+  /// finishes the job.
+  static Color get accent =>
+      AppTheme.pick(const Color(0xFF2261DD), const Color(0xFF4C82F0));
+  static Color get accentHover =>
+      AppTheme.pick(const Color(0xFF0E4EC8), const Color(0xFF6C99F4));
+
+  /// The ring round the selected route card.
+  static Color get accentRing => accent.withValues(alpha: 0.14);
+
+  /// Live: the dot, and the eyebrow over the live pane.
+  static Color get liveDot =>
+      AppTheme.pick(const Color(0xFF269E5F), const Color(0xFF3FB950));
+  static Color get liveInk =>
+      AppTheme.pick(const Color(0xFF007840), const Color(0xFF3FB950));
+
+  /// Idle: the dot when nothing is reachable.
+  static Color get idleDot =>
+      AppTheme.pick(const Color(0xFFA8AEBB), const Color(0xFF6E6E6E));
+
+  /// A route card's badge. The green pair is worn by one badge on the page —
+  /// the server already running here.
+  static Color get badgeFill =>
+      AppTheme.pick(const Color(0xFFEDF0F6), const Color(0xFF2A2A2A));
+  static Color get badgeInk =>
+      AppTheme.pick(const Color(0xFF5F636C), const Color(0xFFB4B4B0));
+  static Color get readyBadgeFill =>
+      AppTheme.pick(const Color(0xFFD2F6DD), const Color(0xFF15321F));
+  static Color get readyBadgeInk =>
+      AppTheme.pick(const Color(0xFF006436), const Color(0xFF6FD68F));
+}
+
+/// The mockup's type scale, by the role each size plays rather than by number.
+///
+/// Sizes and letter-spacing are the design's own. They do not come from
+/// [TextTheme] because the app's scale is a different one — matching the mockup
+/// means saying what it says.
+abstract final class ShareType {
+  /// The rail's headline: "Put this computer to work."
+  static TextStyle get railTitle => TextStyle(
+    fontSize: 27,
+    height: 1.12,
+    fontWeight: AppFont.semibold,
+    letterSpacing: -0.028 * 27,
+    color: SharePalette.ink,
+  );
+
+  /// The rail's paragraph under it.
+  static TextStyle get railBody =>
+      TextStyle(fontSize: 13.5, height: 1.5, color: SharePalette.body);
+
+  /// A pane's headline: "Run a model on this computer."
+  static TextStyle get paneTitle => TextStyle(
+    fontSize: 22,
+    fontWeight: AppFont.semibold,
+    letterSpacing: -0.022 * 22,
+    color: SharePalette.ink,
+  );
+
+  /// A pane's paragraph.
+  static TextStyle get paneBody =>
+      TextStyle(fontSize: 13.5, height: 1.55, color: SharePalette.body);
+
+  /// CHOOSE A ROUTE · ROUTE 01 · LIVE ON THE GRID.
+  static TextStyle get eyebrow => TextStyle(
+    fontSize: 10.5,
+    fontWeight: FontWeight.w700,
+    letterSpacing: 0.1 * 10.5,
+    color: SharePalette.eyebrow,
+  );
+
+  /// A route card's title, and the status block's.
+  static TextStyle get cardTitle => TextStyle(
+    fontSize: 13.5,
+    fontWeight: AppFont.semibold,
+    letterSpacing: -0.01 * 13.5,
+    color: SharePalette.ink,
+  );
+
+  /// A route card's description.
+  static TextStyle get cardLine =>
+      TextStyle(fontSize: 12.3, height: 1.45, color: SharePalette.line);
+
+  /// The sharing status' title.
+  static TextStyle get statusTitle => TextStyle(
+    fontSize: 12.5,
+    fontWeight: AppFont.semibold,
+    color: SharePalette.ink,
+  );
+
+  /// The sharing status' second line, and a helper under a field.
+  static TextStyle get note =>
+      TextStyle(fontSize: 12, height: 1.45, color: SharePalette.note);
+
+  /// The rail's closing note.
+  static TextStyle get footnote =>
+      TextStyle(fontSize: 11.5, height: 1.5, color: SharePalette.helper);
+
+  /// The line that sits beside a button.
+  static TextStyle get buttonHelper =>
+      TextStyle(fontSize: 12.5, color: SharePalette.helper);
+
+  /// A field's label.
+  static TextStyle get fieldLabel => TextStyle(
+    fontSize: 12,
+    fontWeight: AppFont.semibold,
+    color: SharePalette.labelInk,
+  );
+
+  /// A badge on a route card.
+  static TextStyle get badge => TextStyle(
+    fontSize: 10,
+    fontWeight: FontWeight.w700,
+    letterSpacing: 0.06 * 10,
+    height: 1.2,
+  );
+}
+
+/// The mockup's metrics. Named so a number is written once and read where it is
+/// used, rather than typed into six widgets that then drift apart.
+abstract final class ShareMetrics {
+  static const double railWidth = 396;
+  static const EdgeInsets railPadding = EdgeInsets.fromLTRB(28, 34, 28, 28);
+  static const EdgeInsets panePadding = EdgeInsets.fromLTRB(40, 34, 40, 40);
+
+  /// The design holds a pane's prose and forms to this, so a wide window gives
+  /// the reader a column rather than a stretched line.
+  static const double paneMaxWidth = 720;
+
+  /// Between the rail's blocks, and between a pane's.
+  static const double railGap = 26;
+  static const double paneGap = 24;
+
+  /// Card radii: the plate, a route card, the status block, a field, a badge.
+  static const double plateRadius = 13;
+  static const double cardRadius = 11;
+  static const double statusRadius = 10;
+  static const double fieldRadius = 9;
+  static const double badgeRadius = 5;
+
+  /// A plate's own sections.
+  static const EdgeInsets plateSection = EdgeInsets.fromLTRB(20, 18, 20, 18);
+
+  /// A button, and the gap to the line beside it.
+  static const double buttonHeight = 38;
+  static const double buttonGap = 14;
+}

--- a/lib/shared/widgets/advertise_as_field.dart
+++ b/lib/shared/widgets/advertise_as_field.dart
@@ -34,7 +34,12 @@ class AdvertiseAsField extends StatelessWidget {
       'requests to your machine.';
 
   /// The field label; the same concept whether or not the flag is optional.
-  static const _label = 'Model name shown to the grid';
+  ///
+  /// Short enough to sit beside [NodeNameField] in a two-column row without
+  /// either label wrapping. "Model name shown to the grid" said the same thing
+  /// in twice the width, and the word it spent that width on — "model" — is
+  /// already the label on the picker directly above it.
+  static const _label = 'Shown on the grid as';
 
   @override
   Widget build(BuildContext context) {

--- a/lib/shared/widgets/advertise_as_field.dart
+++ b/lib/shared/widgets/advertise_as_field.dart
@@ -59,20 +59,23 @@ class AdvertiseAsField extends StatelessWidget {
               labeledFieldDecoration(
                 hintText ?? '',
                 fill: AppCard.inset,
+                skin: FieldSkinScope.maybeOf(context),
               ).copyWith(
                 suffixIconConstraints: const BoxConstraints(
                   minWidth: 40,
                   maxWidth: 40,
                   maxHeight: 44,
                 ),
-                suffixIcon: Tooltip(
-                  message: _tooltip,
-                  child: Icon(
-                    Icons.help_outline,
-                    size: kFieldIconSize,
-                    color: AppPalette.textFaint,
-                  ),
-                ),
+                suffixIcon: FieldSkinScope.maybeOf(context)?.showHelp == false
+                    ? null
+                    : Tooltip(
+                        message: _tooltip,
+                        child: Icon(
+                          Icons.help_outline,
+                          size: kFieldIconSize,
+                          color: AppPalette.textFaint,
+                        ),
+                      ),
               ),
         ),
       ],

--- a/lib/shared/widgets/app_select_field.dart
+++ b/lib/shared/widgets/app_select_field.dart
@@ -295,7 +295,12 @@ class _FieldSurface extends StatelessWidget {
               ),
             ),
             Icon(
-              Icons.arrow_drop_down,
+              FieldSkinScope.maybeOf(context)?.slimChevron == true
+                  ? Icons.keyboard_arrow_down_rounded
+                  : Icons.arrow_drop_down,
+              // Size 24 (a dropdown's default arrow) so the field matches the
+              // theme's field height instead of shrinking to the 18px icon
+              // theme.
               size: 24,
               color: Theme.of(context).colorScheme.onSurfaceVariant,
             ),

--- a/lib/shared/widgets/app_select_field.dart
+++ b/lib/shared/widgets/app_select_field.dart
@@ -245,6 +245,7 @@ class _FieldSurface extends StatelessWidget {
           '',
           fill: fill ?? AppCard.inset,
           outlined: outlined,
+          skin: FieldSkinScope.maybeOf(context),
         ),
         child: Row(
           children: [

--- a/lib/shared/widgets/context_window_field.dart
+++ b/lib/shared/widgets/context_window_field.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 
 import '../../core/context_length.dart';
 import '../theme/app_theme.dart';
+import '../theme/share_page_theme.dart';
 import 'app_spinner.dart';
 
 /// The "Context window" setting: a collapsed tile showing the current value,
@@ -51,6 +52,7 @@ class ContextWindowField extends StatelessWidget {
       max: max,
       value: value,
       note: note,
+      inline: inline,
       onChanged: (tokens) => onChanged(snapContextLength(tokens, max)),
     );
     if (!inline) {
@@ -59,20 +61,14 @@ class ContextWindowField extends StatelessWidget {
         child: slider,
       );
     }
-    final theme = Theme.of(context);
-    // No value on this header. The box beside the slider holds the exact number
-    // and can be typed into; a rounded copy of it two lines above was a second
-    // reading of one setting, and the two disagreed on sight — "200k" over
-    // "204800" looks like two different numbers to anyone not doing the
-    // arithmetic.
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        Text('Context window', style: theme.textTheme.bodySmall),
-        const SizedBox(height: 6),
-        slider,
-      ],
-    );
+    // Inline is the Share Intelligence design's shape: the setting's name on
+    // the left of one row and its value on the right, then the sentence, then
+    // the slider full width under both. The exact-number box *is* that value —
+    // the design draws a read-only pill there, and this app has to keep the
+    // typing (a server launched with `--ctx-size 40960` cannot be matched by
+    // dragging), so the box wears the pill's shape and sits in the pill's
+    // place. One reading of the setting, in the position the design put it.
+    return slider;
   }
 }
 
@@ -173,12 +169,17 @@ class _SliderAndBox extends StatefulWidget {
     required this.max,
     required this.value,
     required this.note,
+    required this.inline,
     required this.onChanged,
   });
 
   final int max;
   final int value;
   final String? note;
+
+  /// Lay the value out as the design does — beside the label above, not beside
+  /// the slider. See [ContextWindowField.inline].
+  final bool inline;
 
   /// Reports the raw (unsnapped) token count; the parent snaps and clamps it.
   final ValueChanged<int> onChanged;
@@ -235,51 +236,156 @@ class _SliderAndBoxState extends State<_SliderAndBox> {
 
   @override
   Widget build(BuildContext context) {
+    AppTheme.watch(context);
     final theme = Theme.of(context);
-    final endLabel = theme.textTheme.bodySmall?.copyWith(
-      color: theme.colorScheme.onSurfaceVariant,
+    final endLabel = widget.inline
+        ? ShareType.note
+        : theme.textTheme.bodySmall?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          );
+    final box = _TokenBox(
+      controller: _typed,
+      focus: _focus,
+      onCommit: _commit,
+      inline: widget.inline,
+    );
+    final slider = SliderTheme(
+      // The design's slider: a 5px track, and a white thumb ringed in accent
+      // rather than filled with it. Material's default is a fatter track and a
+      // solid dot, which on this page read as a different family of control
+      // from everything around it.
+      data: widget.inline
+          ? SliderThemeData(
+              trackHeight: 5,
+              activeTrackColor: SharePalette.accent,
+              inactiveTrackColor: SharePalette.track,
+              thumbColor: Colors.white,
+              overlayColor: SharePalette.accentRing,
+              thumbShape: const _RingThumb(),
+              trackShape: const RoundedRectSliderTrackShape(),
+            )
+          : SliderTheme.of(context),
+      child: Slider(
+        value: widget.value.toDouble().clamp(
+          minContextTokens.toDouble(),
+          widget.max.toDouble(),
+        ),
+        min: minContextTokens.toDouble(),
+        max: widget.max.toDouble(),
+        label: formatContextLength(widget.value),
+        onChanged: (v) => widget.onChanged(v.round()),
+      ),
     );
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        Text(
-          'How much of your conversation the model can remember and use when it '
-          'replies. Higher remembers more but uses more memory.',
-          style: endLabel,
-        ),
-        if (widget.note case final line?) ...[
-          const SizedBox(height: 4),
-          Text(line, style: endLabel),
-        ],
         Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Expanded(
-              child: Slider(
-                value: widget.value.toDouble().clamp(
-                  minContextTokens.toDouble(),
-                  widget.max.toDouble(),
-                ),
-                min: minContextTokens.toDouble(),
-                max: widget.max.toDouble(),
-                label: formatContextLength(widget.value),
-                onChanged: (v) => widget.onChanged(v.round()),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  // The name of the setting sits *inside* this row in the
+                  // design, so the value beside it lines up with the name
+                  // rather than with the sentence explaining it.
+                  if (widget.inline)
+                    Text('Memory for context', style: ShareType.fieldLabel),
+                  Text(
+                    'How much of your conversation the model can remember and '
+                    'use when it replies. Higher remembers more but uses more '
+                    'memory.',
+                    style: endLabel,
+                  ),
+                  if (widget.note case final line?) ...[
+                    const SizedBox(height: 4),
+                    Text(line, style: endLabel),
+                  ],
+                ],
               ),
             ),
-            const SizedBox(width: 8),
-            _TokenBox(controller: _typed, focus: _focus, onCommit: _commit),
+            if (widget.inline) ...[const SizedBox(width: 16), box],
           ],
         ),
+        if (widget.inline)
+          slider
+        else
+          Row(
+            children: [
+              Expanded(child: slider),
+              const SizedBox(width: 8),
+              box,
+            ],
+          ),
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 8),
           child: Row(
             children: [
-              Text(formatContextLength(minContextTokens), style: endLabel),
+              Text(
+                widget.inline
+                    ? '${formatContextLength(minContextTokens)} · lightest'
+                    : formatContextLength(minContextTokens),
+                style: endLabel,
+              ),
               const Spacer(),
-              Text(formatContextLength(widget.max), style: endLabel),
+              Text(
+                widget.inline
+                    ? '${formatContextLength(widget.max)} · heaviest'
+                    : formatContextLength(widget.max),
+                style: endLabel,
+              ),
             ],
           ),
         ),
       ],
+    );
+  }
+}
+
+/// The design's slider handle: white, ringed in accent, with a soft drop.
+///
+/// Material's `RoundSliderThumbShape` fills the thumb with the active colour,
+/// which reads as a dot *on* the track rather than a handle *over* it.
+class _RingThumb extends SliderComponentShape {
+  const _RingThumb();
+
+  static const double _radius = 8;
+
+  @override
+  Size getPreferredSize(bool isEnabled, bool isDiscrete) =>
+      const Size.fromRadius(_radius);
+
+  @override
+  void paint(
+    PaintingContext context,
+    Offset center, {
+    required Animation<double> activationAnimation,
+    required Animation<double> enableAnimation,
+    required bool isDiscrete,
+    required TextPainter labelPainter,
+    required RenderBox parentBox,
+    required SliderThemeData sliderTheme,
+    required TextDirection textDirection,
+    required double value,
+    required double textScaleFactor,
+    required Size sizeWithOverflow,
+  }) {
+    final canvas = context.canvas;
+    canvas.drawCircle(
+      center.translate(0, 1),
+      _radius,
+      Paint()
+        ..color = SharePalette.ink.withValues(alpha: 0.22)
+        ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 2),
+    );
+    canvas.drawCircle(center, _radius, Paint()..color = Colors.white);
+    canvas.drawCircle(
+      center,
+      _radius - 0.75,
+      Paint()
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = 1.5
+        ..color = SharePalette.accent,
     );
   }
 }
@@ -300,39 +406,51 @@ class _TokenBox extends StatelessWidget {
     required this.controller,
     required this.focus,
     required this.onCommit,
+    required this.inline,
   });
 
   final TextEditingController controller;
   final FocusNode focus;
   final VoidCallback onCommit;
 
+  /// Wear the design's value pill — a filled chip beside the setting's name —
+  /// instead of the app's field. Still typable: it is the same box.
+  final bool inline;
+
   @override
   Widget build(BuildContext context) {
+    AppTheme.watch(context);
     final theme = Theme.of(context);
     return SizedBox(
-      width: 104,
+      width: inline ? 92 : 104,
       child: TextField(
         controller: controller,
         focusNode: focus,
         keyboardType: TextInputType.number,
         inputFormatters: [FilteringTextInputFormatter.digitsOnly],
-        textAlign: TextAlign.right,
+        textAlign: inline ? TextAlign.center : TextAlign.right,
         // Tabular figures: the number changes as the slider moves, and
         // proportional digits make it jitter sideways while it does.
-        style: theme.textTheme.bodyMedium?.copyWith(
-          fontFeatures: const [FontFeature.tabularFigures()],
-        ),
+        style:
+            (inline
+                    ? TextStyle(
+                        fontSize: 14,
+                        fontWeight: AppFont.semibold,
+                        color: SharePalette.ink,
+                      )
+                    : theme.textTheme.bodyMedium)
+                ?.copyWith(fontFeatures: const [FontFeature.tabularFigures()]),
         onSubmitted: (_) => onCommit(),
         decoration: InputDecoration(
           isDense: true,
           filled: true,
-          fillColor: AppPalette.cardBg,
-          contentPadding: const EdgeInsets.symmetric(
+          fillColor: inline ? SharePalette.badgeFill : AppPalette.cardBg,
+          contentPadding: EdgeInsets.symmetric(
             horizontal: 10,
-            vertical: 8,
+            vertical: inline ? 6 : 8,
           ),
           border: OutlineInputBorder(
-            borderRadius: BorderRadius.circular(AppControl.radius),
+            borderRadius: BorderRadius.circular(inline ? 7 : AppControl.radius),
             borderSide: BorderSide.none,
           ),
         ),

--- a/lib/shared/widgets/context_window_field.dart
+++ b/lib/shared/widgets/context_window_field.dart
@@ -208,24 +208,28 @@ class _SliderAndValue extends StatelessWidget {
             min: minContextTokens.toDouble(),
             max: max.toDouble(),
             label: formatContextLength(value),
+            // Edge to edge, as the design draws it. Material insets a slider by
+            // the width of its own thumb so the handle never overhangs its box;
+            // here that left the track short of both margins and the end marks
+            // pointing at nothing. The thumb's 8px does overhang now, and the
+            // section's 20px padding is what absorbs it.
+            padding: EdgeInsets.zero,
             onChanged: (v) => onChanged(v.round()),
           ),
         ),
-        Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 8),
-          child: Row(
-            children: [
-              Text(
-                '${formatContextLength(minContextTokens)} · lightest',
-                style: ShareType.note,
-              ),
-              const Spacer(),
-              Text(
-                '${formatContextLength(max)} · heaviest',
-                style: ShareType.note,
-              ),
-            ],
-          ),
+        const SizedBox(height: 10),
+        Row(
+          children: [
+            Text(
+              '${formatContextLength(minContextTokens)} · lightest',
+              style: ShareType.note,
+            ),
+            const Spacer(),
+            Text(
+              '${formatContextLength(max)} · heaviest',
+              style: ShareType.note,
+            ),
+          ],
         ),
       ],
     );

--- a/lib/shared/widgets/context_window_field.dart
+++ b/lib/shared/widgets/context_window_field.dart
@@ -170,6 +170,7 @@ class _SliderAndValue extends StatelessWidget {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Text('Memory for context', style: ShareType.fieldLabel),
+                  const SizedBox(height: 3),
                   Text(
                     'How much of a conversation the model can hold in mind. '
                     'More context, more RAM.',
@@ -186,6 +187,11 @@ class _SliderAndValue extends StatelessWidget {
             _ValuePill(tokens: value),
           ],
         ),
+        // The three parts of this setting had been stacked flush: name,
+        // sentence, track, marks, with nothing between them. It read as one
+        // dense block rather than as a control with a label — the field rows
+        // above it each get a gap this size between label and box.
+        const SizedBox(height: 14),
         SliderTheme(
           // The design's slider: a 5px track, and a white thumb ringed in
           // accent rather than filled with it. Material's default is a fatter

--- a/lib/shared/widgets/context_window_field.dart
+++ b/lib/shared/widgets/context_window_field.dart
@@ -1,13 +1,12 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 
 import '../../core/context_length.dart';
 import '../theme/app_theme.dart';
 import '../theme/share_page_theme.dart';
 import 'app_spinner.dart';
 
-/// The "Context window" setting: a collapsed tile showing the current value,
-/// opening onto a slider from 4k to [max].
+/// The "Memory for context" setting: the name and the value on one row, the
+/// sentence under it, and a slider from 4k to [max] beneath both.
 ///
 /// Shared because both engine cards ask the same question and §5 wants one
 /// wording and one control for it. They differ only in where [max] comes from —
@@ -20,7 +19,6 @@ class ContextWindowField extends StatelessWidget {
     required this.value,
     required this.onChanged,
     this.note,
-    this.inline = false,
   });
 
   /// The ceiling: the most this engine can actually serve.
@@ -37,38 +35,14 @@ class ContextWindowField extends StatelessWidget {
   /// where [max] came from and whether it can be trusted.
   final String? note;
 
-  /// Draw the slider directly, with a plain label instead of the recessed tile.
-  ///
-  /// For a caller that has *already* folded this away. The tile is a disclosure,
-  /// and a disclosure inside a disclosure inside a disclosure is what the local
-  /// engine form had become: open the row, open "Names and context window",
-  /// then open a boxed tile with its own gear icon to reach one slider. Nesting
-  /// is what made that form read as clutter rather than as three settings.
-  final bool inline;
-
   @override
   Widget build(BuildContext context) {
-    final slider = _SliderAndBox(
+    return _SliderAndValue(
       max: max,
       value: value,
       note: note,
-      inline: inline,
       onChanged: (tokens) => onChanged(snapContextLength(tokens, max)),
     );
-    if (!inline) {
-      return ContextWindowTile(
-        valueLabel: formatContextLength(value),
-        child: slider,
-      );
-    }
-    // Inline is the Share Intelligence design's shape: the setting's name on
-    // the left of one row and its value on the right, then the sentence, then
-    // the slider full width under both. The exact-number box *is* that value —
-    // the design draws a read-only pill there, and this app has to keep the
-    // typing (a server launched with `--ctx-size 40960` cannot be matched by
-    // dragging), so the box wears the pill's shape and sits in the pill's
-    // place. One reading of the setting, in the position the design put it.
-    return slider;
   }
 }
 
@@ -158,18 +132,20 @@ class ContextWindowTile extends StatelessWidget {
   }
 }
 
-/// The slider from 4k to [max], plus a box for typing the exact number.
+/// The slider from 4k to [max], with the value stated beside the setting's
+/// name.
 ///
-/// Two controls for one value, because they answer different needs: dragging is
-/// how you find a size when you don't have one in mind, and typing is how you
-/// enter the number your server was actually launched with. A slider alone
-/// cannot reliably land on 40960, and a box alone gives no sense of the range.
-class _SliderAndBox extends StatefulWidget {
-  const _SliderAndBox({
+/// The value used to be a box you could type into, on the argument that a
+/// server launched with `--ctx-size 40960` cannot be matched by dragging. That
+/// argument moved out from under it: the endpoint form picks its window from a
+/// list now, and a *local* model's window is a choice about memory rather than
+/// a number to match — every value the slider offers is one 1k step away from
+/// the last, so the drag reaches all of them.
+class _SliderAndValue extends StatelessWidget {
+  const _SliderAndValue({
     required this.max,
     required this.value,
     required this.note,
-    required this.inline,
     required this.onChanged,
   });
 
@@ -177,105 +153,12 @@ class _SliderAndBox extends StatefulWidget {
   final int value;
   final String? note;
 
-  /// Lay the value out as the design does — beside the label above, not beside
-  /// the slider. See [ContextWindowField.inline].
-  final bool inline;
-
   /// Reports the raw (unsnapped) token count; the parent snaps and clamps it.
   final ValueChanged<int> onChanged;
 
   @override
-  State<_SliderAndBox> createState() => _SliderAndBoxState();
-}
-
-class _SliderAndBoxState extends State<_SliderAndBox> {
-  late final _typed = TextEditingController(text: '${widget.value}');
-  final _focus = FocusNode();
-
-  @override
-  void initState() {
-    super.initState();
-    _focus.addListener(() {
-      // Committing on blur as well as on Enter: a person who types a number and
-      // then reaches for Start has said what they meant, and losing it there
-      // would be silent.
-      if (!_focus.hasFocus) _commit();
-    });
-  }
-
-  @override
-  void didUpdateWidget(_SliderAndBox old) {
-    super.didUpdateWidget(old);
-    // Follow the slider, but never rewrite the box under someone's cursor.
-    if (widget.value != old.value && !_focus.hasFocus) {
-      _typed.text = '${widget.value}';
-    }
-  }
-
-  @override
-  void dispose() {
-    _typed.dispose();
-    _focus.dispose();
-    super.dispose();
-  }
-
-  /// Take what was typed, or put back what the value actually is.
-  ///
-  /// Nothing is reported per keystroke: typing `8192` passes through `8`, and a
-  /// value clamped to the 4k floor mid-word would fight the person typing it.
-  void _commit() {
-    final typed = int.tryParse(_typed.text.trim());
-    if (typed == null) {
-      _typed.text = '${widget.value}';
-      return;
-    }
-    final settled = snapContextLength(typed, widget.max);
-    _typed.text = '$settled';
-    if (settled != widget.value) widget.onChanged(settled);
-  }
-
-  @override
   Widget build(BuildContext context) {
     AppTheme.watch(context);
-    final theme = Theme.of(context);
-    final endLabel = widget.inline
-        ? ShareType.note
-        : theme.textTheme.bodySmall?.copyWith(
-            color: theme.colorScheme.onSurfaceVariant,
-          );
-    final box = _TokenBox(
-      controller: _typed,
-      focus: _focus,
-      onCommit: _commit,
-      inline: widget.inline,
-    );
-    final slider = SliderTheme(
-      // The design's slider: a 5px track, and a white thumb ringed in accent
-      // rather than filled with it. Material's default is a fatter track and a
-      // solid dot, which on this page read as a different family of control
-      // from everything around it.
-      data: widget.inline
-          ? SliderThemeData(
-              trackHeight: 5,
-              activeTrackColor: SharePalette.accent,
-              inactiveTrackColor: SharePalette.track,
-              thumbColor: Colors.white,
-              overlayColor: SharePalette.accentRing,
-              thumbShape: const _RingThumb(),
-              trackShape: const RoundedRectSliderTrackShape(),
-            )
-          : SliderTheme.of(context),
-      child: Slider(
-        value: widget.value.toDouble().clamp(
-          minContextTokens.toDouble(),
-          widget.max.toDouble(),
-        ),
-        min: minContextTokens.toDouble(),
-        max: widget.max.toDouble(),
-        label: formatContextLength(widget.value),
-        onChanged: (v) => widget.onChanged(v.round()),
-      ),
-    );
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
@@ -286,58 +169,93 @@ class _SliderAndBoxState extends State<_SliderAndBox> {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  // The name of the setting sits *inside* this row in the
-                  // design, so the value beside it lines up with the name
-                  // rather than with the sentence explaining it.
-                  if (widget.inline)
-                    Text('Memory for context', style: ShareType.fieldLabel),
+                  Text('Memory for context', style: ShareType.fieldLabel),
                   Text(
-                    'How much of your conversation the model can remember and '
-                    'use when it replies. Higher remembers more but uses more '
-                    'memory.',
-                    style: endLabel,
+                    'How much of a conversation the model can hold in mind. '
+                    'More context, more RAM.',
+                    style: ShareType.note,
                   ),
-                  if (widget.note case final line?) ...[
+                  if (note case final line?) ...[
                     const SizedBox(height: 4),
-                    Text(line, style: endLabel),
+                    Text(line, style: ShareType.note),
                   ],
                 ],
               ),
             ),
-            if (widget.inline) ...[const SizedBox(width: 16), box],
+            const SizedBox(width: 16),
+            _ValuePill(tokens: value),
           ],
         ),
-        if (widget.inline)
-          slider
-        else
-          Row(
-            children: [
-              Expanded(child: slider),
-              const SizedBox(width: 8),
-              box,
-            ],
+        SliderTheme(
+          // The design's slider: a 5px track, and a white thumb ringed in
+          // accent rather than filled with it. Material's default is a fatter
+          // track and a solid dot, which on this page read as a different
+          // family of control from everything around it.
+          data: SliderThemeData(
+            trackHeight: 5,
+            activeTrackColor: SharePalette.accent,
+            inactiveTrackColor: SharePalette.track,
+            thumbColor: Colors.white,
+            overlayColor: SharePalette.accentRing,
+            thumbShape: const _RingThumb(),
+            trackShape: const RoundedRectSliderTrackShape(),
           ),
+          child: Slider(
+            value: value.toDouble().clamp(
+              minContextTokens.toDouble(),
+              max.toDouble(),
+            ),
+            min: minContextTokens.toDouble(),
+            max: max.toDouble(),
+            label: formatContextLength(value),
+            onChanged: (v) => onChanged(v.round()),
+          ),
+        ),
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 8),
           child: Row(
             children: [
               Text(
-                widget.inline
-                    ? '${formatContextLength(minContextTokens)} · lightest'
-                    : formatContextLength(minContextTokens),
-                style: endLabel,
+                '${formatContextLength(minContextTokens)} · lightest',
+                style: ShareType.note,
               ),
               const Spacer(),
               Text(
-                widget.inline
-                    ? '${formatContextLength(widget.max)} · heaviest'
-                    : formatContextLength(widget.max),
-                style: endLabel,
+                '${formatContextLength(max)} · heaviest',
+                style: ShareType.note,
               ),
             ],
           ),
         ),
       ],
+    );
+  }
+}
+
+/// The window as the reader reads it: "200k tokens" on a quiet chip.
+class _ValuePill extends StatelessWidget {
+  const _ValuePill({required this.tokens});
+
+  final int tokens;
+
+  @override
+  Widget build(BuildContext context) {
+    AppTheme.watch(context);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+      decoration: BoxDecoration(
+        color: SharePalette.badgeFill,
+        borderRadius: BorderRadius.circular(7),
+      ),
+      child: Text(
+        '${formatContextLength(tokens)} tokens',
+        style: TextStyle(
+          fontSize: 14,
+          fontWeight: AppFont.semibold,
+          color: SharePalette.ink,
+          fontFeatures: const [FontFeature.tabularFigures()],
+        ),
+      ),
     );
   }
 }
@@ -386,75 +304,6 @@ class _RingThumb extends SliderComponentShape {
         ..style = PaintingStyle.stroke
         ..strokeWidth = 1.5
         ..color = SharePalette.accent,
-    );
-  }
-}
-
-/// The exact-number box: digits only, wide enough for the largest window the
-/// slider can reach.
-///
-/// Sized for **seven digits** (1048576), not six: a 92px box fitted `204800`
-/// and then clipped a megabyte-scale number into `2048C…`, which is not a
-/// wrong number on screen so much as a plausible-looking one.
-///
-/// No unit suffix inside the box, for the same reason — it competes with the
-/// digits for a width that has to hold the worst case, and the tile it sits in
-/// is already titled "Context window" with the k/M scale at both ends of the
-/// slider.
-class _TokenBox extends StatelessWidget {
-  const _TokenBox({
-    required this.controller,
-    required this.focus,
-    required this.onCommit,
-    required this.inline,
-  });
-
-  final TextEditingController controller;
-  final FocusNode focus;
-  final VoidCallback onCommit;
-
-  /// Wear the design's value pill — a filled chip beside the setting's name —
-  /// instead of the app's field. Still typable: it is the same box.
-  final bool inline;
-
-  @override
-  Widget build(BuildContext context) {
-    AppTheme.watch(context);
-    final theme = Theme.of(context);
-    return SizedBox(
-      width: inline ? 92 : 104,
-      child: TextField(
-        controller: controller,
-        focusNode: focus,
-        keyboardType: TextInputType.number,
-        inputFormatters: [FilteringTextInputFormatter.digitsOnly],
-        textAlign: inline ? TextAlign.center : TextAlign.right,
-        // Tabular figures: the number changes as the slider moves, and
-        // proportional digits make it jitter sideways while it does.
-        style:
-            (inline
-                    ? TextStyle(
-                        fontSize: 14,
-                        fontWeight: AppFont.semibold,
-                        color: SharePalette.ink,
-                      )
-                    : theme.textTheme.bodyMedium)
-                ?.copyWith(fontFeatures: const [FontFeature.tabularFigures()]),
-        onSubmitted: (_) => onCommit(),
-        decoration: InputDecoration(
-          isDense: true,
-          filled: true,
-          fillColor: inline ? SharePalette.badgeFill : AppPalette.cardBg,
-          contentPadding: EdgeInsets.symmetric(
-            horizontal: 10,
-            vertical: inline ? 6 : 8,
-          ),
-          border: OutlineInputBorder(
-            borderRadius: BorderRadius.circular(inline ? 7 : AppControl.radius),
-            borderSide: BorderSide.none,
-          ),
-        ),
-      ),
     );
   }
 }

--- a/lib/shared/widgets/form_plate.dart
+++ b/lib/shared/widgets/form_plate.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+
+import '../theme/app_theme.dart';
+
+/// A form as one plate with its questions ruled apart, rather than a run of
+/// loose fields down a page.
+///
+/// Every route on Share Intelligence asks two or three unrelated things — which
+/// model, what to call it, how much it should remember — and stacking them at
+/// one level made a form with a single real decision in it look like a form with
+/// six. A rule between groups says "this is a different question" in the one
+/// piece of ink that cannot be mistaken for a heading.
+///
+/// **Lifted, not recessed.** The fields inside fill themselves [AppCard.inset];
+/// a recessed plate would be that same `#F7F7F5` and they would vanish into it.
+/// The rim is [AppPalette.divider], the same hairline the app rules everything
+/// else with, so a plate on a white pane still has an edge (§2 — fill alone
+/// cannot separate two surfaces).
+class FormPlate extends StatelessWidget {
+  const FormPlate({super.key, required this.sections});
+
+  /// One group of related fields each. A rule is drawn between them, never
+  /// above the first or below the last.
+  final List<Widget> sections;
+
+  @override
+  Widget build(BuildContext context) {
+    AppTheme.watch(context);
+    return Container(
+      decoration: BoxDecoration(
+        color: AppCard.base,
+        borderRadius: BorderRadius.circular(AppCard.radius),
+        border: Border.all(color: AppPalette.divider),
+        boxShadow: AppGlass.cardShadow,
+      ),
+      clipBehavior: Clip.antiAlias,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          for (final (index, section) in sections.indexed) ...[
+            if (index > 0)
+              Divider(height: 1, thickness: 1, color: AppPalette.divider),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(18, 16, 18, 17),
+              child: section,
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+/// Two fields side by side, stacked instead when the pane is too narrow to give
+/// each one room to be read.
+///
+/// The pair is a pair because the two questions are the same kind — what the
+/// grid calls this model, and what it calls this computer. Desktop windows get
+/// dragged small (§4), and two inputs sharing 300px is worse than two rows.
+class FieldPair extends StatelessWidget {
+  const FieldPair({super.key, required this.first, required this.second});
+
+  final Widget first;
+  final Widget second;
+
+  /// Under this, each field would be narrower than the hint text it shows.
+  static const double _stackBelow = 430;
+
+  @override
+  Widget build(BuildContext context) => LayoutBuilder(
+    builder: (context, constraints) => constraints.maxWidth < _stackBelow
+        ? Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [first, const SizedBox(height: 14), second],
+          )
+        : Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Expanded(child: first),
+              const SizedBox(width: 16),
+              Expanded(child: second),
+            ],
+          ),
+  );
+}

--- a/lib/shared/widgets/form_plate.dart
+++ b/lib/shared/widgets/form_plate.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../theme/app_theme.dart';
+import '../theme/share_page_theme.dart';
 
 /// A form as one plate with its questions ruled apart, rather than a run of
 /// loose fields down a page.
@@ -11,11 +12,10 @@ import '../theme/app_theme.dart';
 /// six. A rule between groups says "this is a different question" in the one
 /// piece of ink that cannot be mistaken for a heading.
 ///
-/// **Lifted, not recessed.** The fields inside fill themselves [AppCard.inset];
-/// a recessed plate would be that same `#F7F7F5` and they would vanish into it.
-/// The rim is [AppPalette.divider], the same hairline the app rules everything
-/// else with, so a plate on a white pane still has an edge (§2 — fill alone
-/// cannot separate two surfaces).
+/// Its two greys are a pair on purpose and come from the design: the rim is
+/// [SharePalette.rim], the rules inside are [SharePalette.innerRule], one shade
+/// lighter — so the plate reads as one object with divisions rather than as
+/// three cards stacked flush.
 class FormPlate extends StatelessWidget {
   const FormPlate({super.key, required this.sections});
 
@@ -28,10 +28,9 @@ class FormPlate extends StatelessWidget {
     AppTheme.watch(context);
     return Container(
       decoration: BoxDecoration(
-        color: AppCard.base,
-        borderRadius: BorderRadius.circular(AppCard.radius),
-        border: Border.all(color: AppPalette.divider),
-        boxShadow: AppGlass.cardShadow,
+        color: SharePalette.surface,
+        borderRadius: BorderRadius.circular(ShareMetrics.plateRadius),
+        border: Border.all(color: SharePalette.rim),
       ),
       clipBehavior: Clip.antiAlias,
       child: Column(
@@ -39,11 +38,8 @@ class FormPlate extends StatelessWidget {
         children: [
           for (final (index, section) in sections.indexed) ...[
             if (index > 0)
-              Divider(height: 1, thickness: 1, color: AppPalette.divider),
-            Padding(
-              padding: const EdgeInsets.fromLTRB(18, 16, 18, 17),
-              child: section,
-            ),
+              Divider(height: 1, thickness: 1, color: SharePalette.innerRule),
+            Padding(padding: ShareMetrics.plateSection, child: section),
           ],
         ],
       ),
@@ -63,6 +59,9 @@ class FieldPair extends StatelessWidget {
   final Widget first;
   final Widget second;
 
+  /// The design's own column gap.
+  static const double _gap = 16;
+
   /// Under this, each field would be narrower than the hint text it shows.
   static const double _stackBelow = 430;
 
@@ -71,13 +70,17 @@ class FieldPair extends StatelessWidget {
     builder: (context, constraints) => constraints.maxWidth < _stackBelow
         ? Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [first, const SizedBox(height: 14), second],
+            children: [
+              first,
+              const SizedBox(height: _gap),
+              second,
+            ],
           )
         : Row(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Expanded(child: first),
-              const SizedBox(width: 16),
+              const SizedBox(width: _gap),
               Expanded(child: second),
             ],
           ),

--- a/lib/shared/widgets/labeled_field.dart
+++ b/lib/shared/widgets/labeled_field.dart
@@ -21,6 +21,7 @@ class FieldSkin {
     required this.hintSize,
     required this.labelStyle,
     this.showHelp = true,
+    this.slimChevron = false,
   });
 
   final Color fill;
@@ -39,6 +40,11 @@ class FieldSkin {
   /// and a `?` in each is two question marks in one row of a form with nothing
   /// obscure in it.
   final bool showHelp;
+
+  /// Draw a picker's disclosure as a thin chevron rather than Material's solid
+  /// triangle. The design's, and it matches the hairline weight of everything
+  /// else on that page — a filled wedge is the heaviest mark in the form.
+  final bool slimChevron;
 }
 
 /// Hangs a [FieldSkin] over a subtree.

--- a/lib/shared/widgets/labeled_field.dart
+++ b/lib/shared/widgets/labeled_field.dart
@@ -3,6 +3,57 @@ import 'package:flutter/services.dart';
 
 import '../theme/app_theme.dart';
 
+/// A field's chrome, when a screen needs one other than the app's own.
+///
+/// The app draws a field as a soft borderless capsule, radius 12, filled
+/// [AppPalette.cardBg]. Share Intelligence was designed with a *visible* field:
+/// a 1px rim, radius 9, a lighter fill, and a smaller label. Rather than plumb
+/// six numbers through seven widgets, the page hangs one of these over its
+/// subtree and every field built through [labeledFieldDecoration] picks it up.
+///
+/// Null everywhere else, which is what keeps the rest of the app untouched.
+class FieldSkin {
+  const FieldSkin({
+    required this.fill,
+    required this.rim,
+    required this.radius,
+    required this.contentPadding,
+    required this.hintSize,
+    required this.labelStyle,
+    this.showHelp = true,
+  });
+
+  final Color fill;
+  final Color rim;
+  final double radius;
+  final EdgeInsets contentPadding;
+  final double hintSize;
+
+  /// The label above the control — a field's chrome includes what names it.
+  final TextStyle labelStyle;
+
+  /// Whether a field that has a help tooltip still shows the glyph for it.
+  ///
+  /// False on Share Intelligence, where the design draws a bare field: the two
+  /// name boxes sit side by side under labels that already say what they are,
+  /// and a `?` in each is two question marks in one row of a form with nothing
+  /// obscure in it.
+  final bool showHelp;
+}
+
+/// Hangs a [FieldSkin] over a subtree.
+class FieldSkinScope extends InheritedWidget {
+  const FieldSkinScope({super.key, required this.skin, required super.child});
+
+  final FieldSkin skin;
+
+  static FieldSkin? maybeOf(BuildContext context) =>
+      context.dependOnInheritedWidgetOfExactType<FieldSkinScope>()?.skin;
+
+  @override
+  bool updateShouldNotify(FieldSkinScope oldWidget) => oldWidget.skin != skin;
+}
+
 /// A field's label, sitting still above the control it names.
 ///
 /// Material floats a `labelText` *inside* the field and animates it up to the
@@ -21,15 +72,19 @@ class FieldLabel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    AppTheme.watch(context);
+    final skin = FieldSkinScope.maybeOf(context);
     return Padding(
       padding: const EdgeInsets.only(left: 2, bottom: 8),
       child: Text(
         text,
-        style: TextStyle(
-          fontSize: 12.5,
-          fontWeight: AppFont.medium,
-          color: AppPalette.textSecondary,
-        ),
+        style:
+            skin?.labelStyle ??
+            TextStyle(
+              fontSize: 12.5,
+              fontWeight: AppFont.medium,
+              color: AppPalette.textSecondary,
+            ),
       ),
     );
   }
@@ -122,6 +177,7 @@ class LabeledField extends StatelessWidget {
             hint,
             fill: fill,
             hasError: error != null,
+            skin: FieldSkinScope.maybeOf(context),
           ),
         ),
         if (error != null) _FieldError(error!),
@@ -144,10 +200,14 @@ InputDecoration labeledFieldDecoration(
   Color? fill,
   bool hasError = false,
   bool outlined = false,
+  FieldSkin? skin,
 }) {
+  // A skin rims the field at rest; [outlined] is the app's own way of asking
+  // for the same thing, so either one turns the hairline on.
+  final rimmed = outlined || skin != null;
   OutlineInputBorder border(Color color, [double width = 1]) =>
       OutlineInputBorder(
-        borderRadius: BorderRadius.circular(12),
+        borderRadius: BorderRadius.circular(skin?.radius ?? 12),
         borderSide: width == 0
             ? BorderSide.none
             : BorderSide(color: color, width: width),
@@ -155,13 +215,15 @@ InputDecoration labeledFieldDecoration(
   return InputDecoration(
     hintText: hint,
     filled: true,
-    fillColor: fill ?? AppPalette.cardBg,
+    fillColor: skin?.fill ?? fill ?? AppPalette.cardBg,
     hintStyle: TextStyle(
-      fontSize: 14,
+      fontSize: skin?.hintSize ?? 14,
       height: 1.4,
       color: AppPalette.textFaint,
     ),
-    contentPadding: const EdgeInsets.symmetric(horizontal: 14, vertical: 13),
+    contentPadding:
+        skin?.contentPadding ??
+        const EdgeInsets.symmetric(horizontal: 14, vertical: 13),
     // The error hairline shows whether or not the field has focus — an error the
     // user has to click back into the field to see is an error they won't see.
     border: border(Colors.transparent, 0),
@@ -174,12 +236,12 @@ InputDecoration labeledFieldDecoration(
     enabledBorder: hasError
         ? border(fieldErrorInk(), 1.5)
         : border(
-            outlined ? AppPalette.divider : Colors.transparent,
-            outlined ? 1 : 0,
+            rimmed ? (skin?.rim ?? AppPalette.divider) : Colors.transparent,
+            rimmed ? 1 : 0,
           ),
     disabledBorder: border(
-      outlined ? AppPalette.divider : Colors.transparent,
-      outlined ? 1 : 0,
+      rimmed ? (skin?.rim ?? AppPalette.divider) : Colors.transparent,
+      rimmed ? 1 : 0,
     ),
     focusedBorder: border(hasError ? fieldErrorInk() : AppPalette.accent, 1.5),
   );

--- a/lib/shared/widgets/node_name_field.dart
+++ b/lib/shared/widgets/node_name_field.dart
@@ -47,20 +47,23 @@ class NodeNameField extends StatelessWidget {
               labeledFieldDecoration(
                 hintText ?? '',
                 fill: AppCard.inset,
+                skin: FieldSkinScope.maybeOf(context),
               ).copyWith(
                 suffixIconConstraints: const BoxConstraints(
                   minWidth: 40,
                   maxWidth: 40,
                   maxHeight: 44,
                 ),
-                suffixIcon: Tooltip(
-                  message: _tooltip,
-                  child: Icon(
-                    Icons.help_outline,
-                    size: kFieldIconSize,
-                    color: AppPalette.textFaint,
-                  ),
-                ),
+                suffixIcon: FieldSkinScope.maybeOf(context)?.showHelp == false
+                    ? null
+                    : Tooltip(
+                        message: _tooltip,
+                        child: Icon(
+                          Icons.help_outline,
+                          size: kFieldIconSize,
+                          color: AppPalette.textFaint,
+                        ),
+                      ),
               ),
         ),
       ],

--- a/lib/shared/widgets/node_name_field.dart
+++ b/lib/shared/widgets/node_name_field.dart
@@ -25,7 +25,10 @@ class NodeNameField extends StatelessWidget {
       'How this computer appears on the grid, so you can tell your machines '
       'apart. It does not change which models you serve.';
 
-  static const _label = "This computer's name on the grid";
+  /// Paired with [AdvertiseAsField]'s, and trimmed for the same reason: the two
+  /// sit side by side, and "on the grid" is what the field above it already
+  /// establishes both names are for.
+  static const _label = "This computer's name";
 
   @override
   Widget build(BuildContext context) {

--- a/test/provider_node/context_ladder_test.dart
+++ b/test/provider_node/context_ladder_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:grid_app/features/provider_node/logic/context_ladder.dart';
+
+/// The endpoint form picks a context window from a list rather than a slider,
+/// so the list is the only thing standing between a user and a silently changed
+/// setting: a rung missing here is a value they can no longer choose, and a
+/// rung above the server's ceiling is a start that fails after the join.
+
+void main() {
+  group('contextLadder', () {
+    test('never offers more than the server can serve', () {
+      final ladder = contextLadder(max: 40960, current: 40960);
+      expect(ladder.every((rung) => rung <= 40960), isTrue);
+      expect(ladder.last, 40960, reason: 'the ceiling is worth offering');
+    });
+
+    test('keeps a value already in force even when it is off the ladder', () {
+      final ladder = contextLadder(max: 262144, current: 40960);
+      expect(
+        ladder,
+        contains(40960),
+        reason:
+            'a server launched with --ctx-size 40960 must not be rounded to '
+            '32k by the act of opening the picker',
+      );
+    });
+
+    test('offers the familiar sizes under the ceiling, in order', () {
+      final ladder = contextLadder(max: 262144, current: 204800);
+      expect(ladder, [4096, 8192, 16384, 32768, 65536, 131072, 204800, 262144]);
+    });
+
+    test('a tiny ceiling still yields a usable list, never an empty one', () {
+      expect(contextLadder(max: 0, current: 0), [4096]);
+      expect(contextLadder(max: 4096, current: 4096), [4096]);
+    });
+
+    test('lists every rung once, however the current value lines up', () {
+      final ladder = contextLadder(max: 131072, current: 131072);
+      expect(ladder.toSet().length, ladder.length);
+    });
+  });
+}

--- a/test/provider_node/share_route_test.dart
+++ b/test/provider_node/share_route_test.dart
@@ -1,0 +1,92 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:grid_app/features/provider_node/logic/share_route.dart';
+
+/// The page opens on whichever route it picks here, and the route it opens on
+/// is the one most people will take. Opening on a route this machine cannot
+/// take is the failure worth guarding: it puts a form in front of someone whose
+/// first move has to be somewhere else entirely.
+
+void main() {
+  group('defaultShareRoute', () {
+    test('leads with the local engine when this machine can run one', () {
+      expect(
+        defaultShareRoute(
+          canRunLocal: true,
+          serverFound: false,
+          hasKeyProvider: false,
+        ),
+        ShareRoute.local,
+        reason: 'the only route that costs nothing and sends nothing',
+      );
+    });
+
+    test('still leads with local when the other two are also available', () {
+      expect(
+        defaultShareRoute(
+          canRunLocal: true,
+          serverFound: true,
+          hasKeyProvider: true,
+        ),
+        ShareRoute.local,
+        reason:
+            'detection lands after the first frame, so a default that changed '
+            'once Ollama was found would move the page under the reader',
+      );
+    });
+
+    test('offers a server already running here when local is impossible', () {
+      expect(
+        defaultShareRoute(
+          canRunLocal: false,
+          serverFound: true,
+          hasKeyProvider: true,
+        ),
+        ShareRoute.server,
+        reason: 'one press from shared, against a key that has to be found',
+      );
+    });
+
+    test('falls to a key when there is no engine and no server', () {
+      expect(
+        defaultShareRoute(
+          canRunLocal: false,
+          serverFound: false,
+          hasKeyProvider: true,
+        ),
+        ShareRoute.key,
+      );
+    });
+
+    test('never opens on a route this machine cannot take', () {
+      for (final serverFound in [true, false]) {
+        for (final hasKey in [true, false]) {
+          expect(
+            defaultShareRoute(
+              canRunLocal: false,
+              serverFound: serverFound,
+              hasKeyProvider: hasKey,
+            ),
+            isNot(ShareRoute.local),
+            reason:
+                'no built-in engine here, so the local form has nothing to '
+                'run — found=$serverFound key=$hasKey',
+          );
+        }
+      }
+    });
+
+    test('lands on the endpoint form when nothing at all was detected', () {
+      expect(
+        defaultShareRoute(
+          canRunLocal: false,
+          serverFound: false,
+          hasKeyProvider: false,
+        ),
+        ShareRoute.server,
+        reason:
+            'it takes a typed address, so it is the one route that is always '
+            'available — a page has to open on something',
+      );
+    });
+  });
+}


### PR DESCRIPTION
The page was three stacked disclosures: rows you opened one at a time, each
unfolding a form under the two you hadn't read. That shape asks you to compare
options by opening and closing them, and it buried the cheapest route — a key,
no download — under two rows about hardware.

It is now two panes, built to the designer's mockup.

## The rail

What the page is for, whether this computer is reachable right now, and the
three ways in as cards that stay visible while one is being configured.

- **Run a local model** — your own hardware, weights and prompts never leave.
- **Share frontier models via your API key** — nothing to download; you pay for
  what the grid uses.
- **Start an engine you already have** — Ollama and friends, named by what was
  actually found on the machine.

Which routes appear is what the machine can *do*: `buildShareRouteOffers` leaves
a route out rather than drawing it disabled, and `defaultShareRoute` never opens
on one this computer cannot take. Both are pure and tested.

## The panes

Each route gets its eyebrow, headline, paragraph and form. The forms are the
same ones the rows used to open — being three-deep was the problem, not the
fields — but each is now a `FormPlate`: one surface with its questions ruled
apart, so a form with a single real decision stops looking like a form with six.

The local engine's names and context window came back out of the "Shared as …
Change" sentence they were folded into. Hidden, they were *unverifiable*, and a
form whose only visible control is a dropdown gives you nothing to check before
pressing a button that puts your machine on a network.

The endpoint route's context window is a picker rather than a slider — a
server's window is a number it was *launched with*. `contextLadder` keeps
whatever is already set as its own rung, so opening it can never round somebody's
`--ctx-size 40960` to the nearest familiar number.

## Matching the mockup

`share_page_theme.dart` carries the design's palette, type and metrics, read off
the file and converted from oklch. Two mechanisms reach the shared widgets
without threading parameters through seven of them:

- **`FieldSkin` + `FieldSkinScope`** — the page hangs one skin over its subtree
  and every field built through `labeledFieldDecoration` picks up the rim,
  radius, fill, label, help glyph and chevron. Null everywhere else, so no other
  screen moves.
- **A `Theme` override on the page** for buttons and links, which is how
  Material already resolves them, so it reaches `EngineStartButton` and every
  `TextButton` inside widgets this page does not own.

Verified by rendering the designer's own bundle in headless Chrome and sampling
both images: grounds, plate, field, badge, button and track match to the value,
allowing for the P3 shift a screen capture adds.

## ⚠️ Where the design and the app disagreed

The app won each time, and each is commented at the line:

- **No live stat panel.** The mockup draws requests, tokens out, uptime and
  median latency. Nothing here measures any of the four for *this* machine, and
  four invented figures is the one thing a dashboard must never do (§5). A
  `TODO(BE)` records that the grid overview *does* carry per-node answered
  totals and what wiring them up would take.
- **No "≈ 10.7 GB RAM reserved".** The mockup computes it as
  `ctx/1024 * 0.046 + 1.5`. Nothing here knows a model's KV cache.
- **No keychain.** "Keys stay in your keychain" — this app has none; a key goes
  to the local `grid` CLI.
- **No "Read-only checks only. No billing changes."** The key answers questions,
  which is exactly what bills the account. The mockup's own paragraph
  contradicts it.
- **Nothing about GPUs, minutes or prompt logging.** Claims about hardware,
  timing and behaviour we cannot check.
- **Four of the design's inks are under §11's 4.5:1 floor** on its own grounds
  (line 4.29, note 4.11, helper 3.78, eyebrow 3.49). They ship because the
  mockup is the brief; `share_page_theme.dart` records the measurements and the
  one-step darkening that clears them. **A decision to take, not inherit.**

Dark values are derived, not designed — the mockup is light-only.

## Merge note

`main` is merged in. Its `93e30c91` wrapped this page's body in
`SelectableBody`; that body no longer exists, so git offered to restore
`_ServeSection` and undo the branch. Taken as intent instead: the rule is inside
a scroll view, never around one, and this page has five where the old one had a
single `ListView`.

## Checks

- `flutter analyze lib test` → **0 issues** (Flutter 3.44.4, the CI pin).
- **2999 tests pass, 3 fail.** Two in `test/agent/claude_exec_test.dart` fail
  identically on a clean `main` worktree — `d6a185c5` commented out
  `kClaudeSessionSchedulerTools` without touching the tests that assert it, so
  **`main` is red right now**. One each in `chat_sessions_reload_test` and
  `panel_controller_test` pass when their file is run alone.
- No widget tests added (§8). New logic is covered: `share_route_test.dart` and
  `context_ladder_test.dart`.
- Verified in the running app at 1280x800, 1640x900 and 900x700, where the two
  panes stack rather than crush each other.

## Not verified

The **live pane** — what the page shows once this computer is actually serving.
It needs a real engine running; I've only read it.
