### PR TITLE
Rebuild the grid picker: rows you can compare, then a button

### DIFF
--- a/lib/features/network/logic/grid_access_summary.dart
+++ b/lib/features/network/logic/grid_access_summary.dart
@@ -27,7 +27,30 @@ enum GridAccessTag {
   const GridAccessTag(this.label);
 
   final String label;
+
+  /// The heading this tag becomes when the list is grouped under it.
+  ///
+  /// Said from the reader's side and in the plural, because a heading names a
+  /// set rather than a row: "Owner" over three rows reads as a label somebody
+  /// forgot to put on each of them.
+  String get groupLabel => switch (this) {
+    GridAccessTag.owner => 'YOURS',
+    GridAccessTag.invited => "YOU'RE INVITED",
+    GridAccessTag.public => 'OPEN TO ANYONE',
+  };
 }
+
+/// The order a grouped list shows the tags in: what is yours, what you were let
+/// into, then what is open to everyone.
+///
+/// Not [GridAccessTag.values], whose order exists for a different job — there
+/// `public` leads because openness is the fact a *row* must not bury. A list
+/// leads with the grids the reader already has a stake in.
+const kGridGroupOrder = [
+  GridAccessTag.owner,
+  GridAccessTag.invited,
+  GridAccessTag.public,
+];
 
 /// The access rule behind a `network_type` wire value, or null when it is one
 /// this app never offers.

--- a/lib/features/network/logic/grid_choice_row.dart
+++ b/lib/features/network/logic/grid_choice_row.dart
@@ -1,0 +1,94 @@
+import '../../../shared/copy/plural.dart';
+import '../../../infrastructure/state/models/network_credential.dart';
+import 'grid_access_summary.dart';
+
+/// What one grid's row says about itself under its name.
+///
+/// The design puts a live sentence there — how many computers are answering,
+/// and what the grid holds — which is the difference between choosing a grid
+/// and guessing at one. Everything it can say comes from that grid's own
+/// overview, probed per grid; nothing is inferred, and the two states where
+/// there is no answer yet say so rather than reporting zero.
+sealed class GridLiveness {
+  const GridLiveness();
+}
+
+/// The probe is still out. Distinct from "nothing is answering", which is what
+/// a zero here would be read as — and would be wrong for the second or two it
+/// takes every grid on the account to reply.
+class GridChecking extends GridLiveness {
+  const GridChecking();
+}
+
+/// The grid did not answer. Says so rather than reporting an empty grid: a
+/// control plane that is down is not a grid with nobody on it, and the reader
+/// picking between them needs to know which they are looking at.
+class GridUnreachable extends GridLiveness {
+  const GridUnreachable();
+}
+
+/// The grid answered.
+class GridReached extends GridLiveness {
+  const GridReached({
+    required this.running,
+    required this.nodes,
+    required this.models,
+  });
+
+  /// Whether the grid reports itself as answering — the same field the Grids
+  /// list colours its bolt from, so the two can never disagree.
+  final bool running;
+
+  final int nodes;
+  final int models;
+}
+
+/// The sentence under a grid's name.
+///
+/// Pure, because this is the line that goes stale silently: it is assembled
+/// from three numbers and a state, and every one of them has a "we don't know
+/// yet" that reads as a fact if it is allowed to fall through to zero.
+String gridRowMeta(GridLiveness liveness) => switch (liveness) {
+  GridChecking() => 'Checking…',
+  GridUnreachable() => "Can't reach this grid right now",
+  GridReached(running: false) => 'Nobody answering right now',
+  GridReached(:final nodes) when nodes == 0 => 'Answering now',
+  GridReached(:final nodes, :final models) when models == 0 =>
+    '$nodes ${plural(nodes, 'computer')} answering',
+  GridReached(:final nodes, :final models) =>
+    '$nodes ${plural(nodes, 'computer')} answering · '
+        '$models ${plural(models, 'model')}',
+};
+
+/// The grids on this account, in the order and groups the list draws them.
+///
+/// Empty groups are left out entirely rather than drawn as a heading over
+/// nothing — on most accounts two of the three are empty.
+List<({GridAccessTag tag, List<NetworkCredential> grids})> groupGrids(
+  List<NetworkCredential> networks,
+) => [
+  for (final tag in kGridGroupOrder)
+    if (networks.where((n) => gridAccessTagFor(n) == tag).toList()
+        case final grids when grids.isNotEmpty)
+      (tag: tag, grids: grids),
+];
+
+/// The grids whose name contains [query], case- and space-insensitively.
+///
+/// A blank query is not a filter — it returns everything rather than nothing,
+/// which is the bug this shape exists to make impossible.
+List<NetworkCredential> filterGrids(
+  List<NetworkCredential> networks,
+  String query,
+) {
+  final needle = query.trim().toLowerCase();
+  if (needle.isEmpty) return networks;
+  return [
+    for (final network in networks)
+      if (network.name.toLowerCase().contains(needle)) network,
+  ];
+}
+
+/// The count beside the search box: "12 grids", or "3 of 12" while filtering.
+String gridCountLabel({required int shown, required int total}) =>
+    shown == total ? '$total ${plural(total, 'grid')}' : '$shown of $total';

--- a/lib/features/network/logic/grid_choice_row.dart
+++ b/lib/features/network/logic/grid_choice_row.dart
@@ -35,30 +35,42 @@ class GridReached extends GridLiveness {
     required this.models,
   });
 
-  /// Whether the grid reports itself as answering — the same field the Grids
-  /// list colours its bolt from, so the two can never disagree.
+  /// Whether the grid itself reports as up — the same field the Grids list
+  /// colours its bolt from.
   final bool running;
 
   final int nodes;
   final int models;
 }
 
+/// Whether anything is actually answering on this grid.
+///
+/// The count, not the state. A grid can report `running` with nothing on it —
+/// two on this account do — and reading the state alone put a green dot beside
+/// a grid that could not answer a single question. The dot and the sentence
+/// below it both come through here now, so they cannot say different things
+/// about the same grid.
+bool gridIsAnswering(GridLiveness liveness) => switch (liveness) {
+  GridReached(:final running, :final nodes) => running && nodes > 0,
+  _ => false,
+};
+
 /// The sentence under a grid's name.
 ///
 /// Pure, because this is the line that goes stale silently: it is assembled
 /// from three numbers and a state, and every one of them has a "we don't know
 /// yet" that reads as a fact if it is allowed to fall through to zero.
-String gridRowMeta(GridLiveness liveness) => switch (liveness) {
-  GridChecking() => 'Checking…',
-  GridUnreachable() => "Can't reach this grid right now",
-  GridReached(running: false) => 'Nobody answering right now',
-  GridReached(:final nodes) when nodes == 0 => 'Answering now',
-  GridReached(:final nodes, :final models) when models == 0 =>
-    '$nodes ${plural(nodes, 'computer')} answering',
-  GridReached(:final nodes, :final models) =>
-    '$nodes ${plural(nodes, 'computer')} answering · '
-        '$models ${plural(models, 'model')}',
-};
+String gridRowMeta(GridLiveness liveness) {
+  if (liveness is GridChecking) return 'Checking…';
+  if (liveness is GridUnreachable) return "Can't reach this grid right now";
+  if (!gridIsAnswering(liveness)) return 'No computers answering';
+  final reached = liveness as GridReached;
+  final computers =
+      '${reached.nodes} ${plural(reached.nodes, 'computer')} answering';
+  if (reached.models == 0) return computers;
+  return '$computers · ${reached.models} '
+      '${plural(reached.models, 'model')}';
+}
 
 /// The grids on this account, in the order and groups the list draws them.
 ///

--- a/lib/features/onboarding/presentation/grid_choice_screen.dart
+++ b/lib/features/onboarding/presentation/grid_choice_screen.dart
@@ -1,14 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../infrastructure/analytics/analytics_events.dart';
+import '../../../infrastructure/analytics/analytics_providers.dart';
+import '../../../infrastructure/state/models/network_credential.dart';
 import '../../../shared/layouts/onboarding_page.dart';
 import '../../../shared/theme/app_theme.dart';
-import '../../../shared/widgets/choice_row.dart';
-import '../../../shared/widgets/detail_widgets.dart';
 import '../../auth/logic/session_controller.dart';
-import '../../network/logic/grid_access_summary.dart';
+import '../../network/logic/grid_choice.dart';
+import '../../network/logic/grid_choice_row.dart';
 import '../../network/logic/grid_sync_controller.dart';
 import 'widgets/grid_pick_list.dart';
+import 'widgets/grid_search_field.dart';
 import 'widgets/new_grid_form.dart';
 
 /// The first thing after signing in: which grid is this?
@@ -19,13 +22,13 @@ import 'widgets/new_grid_form.dart';
 /// screen behind this one reads the answer (what model the grid serves, where
 /// chat sends, what this computer would share), so it is worth one screen.
 ///
-/// The explaining splits by whether the reader can do without it. What a grid
-/// *is* stays in the subtitle: someone who does not know cannot know to go
-/// looking behind a link for it. What the three labels mean folds away under
-/// the list, because the labels are on the rows and most people never ask.
+/// Choosing is two steps now: press a grid, then press the button. That reads
+/// like a step too many until you have three grids and no idea which of them
+/// has anything running — the rows carry that, and a list you can compare is
+/// only comparable if pressing one doesn't end the screen.
 ///
 /// Asked once per sign-in. [gridChoiceNeededProvider] is false the moment a grid
-/// is picked, and with "Remember my choice" ticked the answer survives a
+/// is entered, and with "Always start here" ticked the answer survives a
 /// relaunch too — but never a sign-out, which clears it (`AuthController`).
 class GridChoiceScreen extends ConsumerStatefulWidget {
   const GridChoiceScreen({super.key});
@@ -35,11 +38,15 @@ class GridChoiceScreen extends ConsumerStatefulWidget {
 }
 
 class _GridChoiceScreenState extends ConsumerState<GridChoiceScreen> {
-  /// Whether the create form is showing. Null until the user says either way,
+  /// The grid the button would enter. Null until the reader picks, which is
+  /// also what keeps the button honest about having nothing to do yet.
+  String? _selectedId;
+
+  /// Whether the create block is open. Null until the reader says either way,
   /// so the default below can follow the account.
   bool? _creating;
 
-  /// Whether picking a grid writes it down for next time.
+  /// Whether entering a grid writes it down for next time.
   ///
   /// Ticked by default: most people work on one grid, and asking them the same
   /// question at every launch is friction with nothing to show for it. The tick
@@ -47,10 +54,7 @@ class _GridChoiceScreenState extends ConsumerState<GridChoiceScreen> {
   /// choice is made, not buried in Settings afterwards.
   bool _remember = true;
 
-  /// Whether the labels note is open. Shut to begin with: the people who need
-  /// it are a minority of launches, and a glossary unfolded under the list
-  /// makes everyone else scroll past an answer to a question they did not ask.
-  bool _explaining = false;
+  final _query = TextEditingController();
 
   @override
   void initState() {
@@ -69,85 +73,137 @@ class _GridChoiceScreenState extends ConsumerState<GridChoiceScreen> {
   }
 
   @override
+  void dispose() {
+    _query.dispose();
+    super.dispose();
+  }
+
+  void _enter(NetworkCredential network) {
+    ref.read(analyticsProvider).gridChoice('existing');
+    ref
+        .read(gridChoiceGateProvider.notifier)
+        .choose(network, remember: _remember);
+  }
+
+  @override
   Widget build(BuildContext context) {
+    AppTheme.watch(context);
     final networks = ref.watch(sessionProvider).networks;
-    final hasGrids = networks.isNotEmpty;
-    // An account with no grids has only one honest answer, so the create form
-    // opens itself rather than making the user press a row whose alternative
-    // isn't there. Otherwise the list leads: picking is one click from here.
-    final creating = _creating ?? !hasGrids;
+    final matches = filterGrids(networks, _query.text);
+    final selected = matches
+        .where((n) => n.networkId == _selectedId)
+        .firstOrNull;
+    // An account with no grids has only one honest answer, so the create block
+    // opens itself rather than making the reader press a row whose alternative
+    // isn't there. Otherwise the list leads.
+    final creating = _creating ?? networks.isEmpty;
 
     return OnboardingPage(
       // A question the reader can answer, in words carrying no product
       // vocabulary at all. "Choose your grid" asked them to pick one of a thing
       // they had never heard of, using its name as though they already knew it.
       title: 'Where should your chats run?',
-      // Three short sentences doing three jobs: what the word means, what to do
-      // about it, and that doing it is reversible. It sat behind the link for a
-      // while, which was wrong — a reader who does not know what a grid is
-      // cannot know to go looking behind a link for it. What belongs there is
-      // the part that is optional.
+      // What the word means, what to do about it, and that doing it is
+      // reversible — a reader who does not know what a grid is cannot know to
+      // go looking behind a link for it.
       subtitle:
-          'A grid is a group of computers that answer your chats. Choose one '
-          'to get started. You can switch anytime.',
+          'A grid is a set of computers that answer your chats. Pick one to '
+          'get started. Switching later takes a click.',
+      footer: _Footer(
+        remember: _remember,
+        onRemember: (next) => setState(() => _remember = next),
+        // Nothing to confirm while the create block is open: that block has its
+        // own button, and two primaries on one screen is a coin toss.
+        selected: creating ? null : selected,
+        onEnter: () => _enter(selected!),
+      ),
       children: [
-        if (hasGrids) ...[
-          GridPickList(remember: _remember),
-          const SizedBox(height: 8),
-          // One quiet row under the list carrying both asides: what the labels
-          // on it mean, and whether this answer is kept. Neither is a step, and
-          // on separate lines they read like two more of them.
-          //
-          // Wrap, not Row: both halves grow with the user's font size, and on a
-          // narrow card they drop onto their own lines rather than overflow.
-          Wrap(
-            alignment: WrapAlignment.spaceBetween,
-            crossAxisAlignment: WrapCrossAlignment.center,
-            runSpacing: 2,
-            children: [
-              _LabelsLink(
-                onToggle: () => setState(() => _explaining = !_explaining),
-              ),
-              _RememberChoice(
-                value: _remember,
-                onChanged: (next) => setState(() => _remember = next),
-              ),
-            ],
-          ),
-          _LabelsReveal(open: _explaining),
-          const SizedBox(height: 18),
-        ],
-        ChoiceRowGroup(
-          outlined: true,
-          children: [
-            ChoiceRow(
-              icon: const Icon(Icons.add_circle_outline),
-              // One line, like the rows above it: those are single-line items,
-              // and a heavier action under them read as a different weight of
-              // thing. Who can join is the form's own first question, so the
-              // row does not need to promise it in advance.
-              title: 'Create a new grid',
-              action: ChoiceRowAction.open,
-              expanded: creating,
-              onPressed: () => setState(() => _creating = !creating),
-              child: creating ? const NewGridForm() : null,
+        // Only once the list is long enough to be worth searching. Below that
+        // it is a box that costs a row of height to save nobody any scrolling.
+        if (networks.length > 5) ...[
+          GridSearchField(
+            controller: _query,
+            countLabel: gridCountLabel(
+              shown: matches.length,
+              total: networks.length,
             ),
-          ],
+            onChanged: (_) => setState(() {}),
+          ),
+          const SizedBox(height: 12),
+        ],
+        if (networks.isNotEmpty)
+          GridPickList(
+            networks: matches,
+            selected: creating ? null : selected,
+            onSelect: (network) => setState(() {
+              _selectedId = network.networkId;
+              _creating = false;
+            }),
+          ),
+        const SizedBox(height: 6),
+        NewGridForm(
+          open: creating,
+          onToggle: () => setState(() {
+            _creating = !creating;
+            if (_creating!) _selectedId = null;
+          }),
         ),
       ],
     );
   }
 }
 
-/// The tick deciding whether this answer outlives the session.
-///
-/// One quiet line, sized and coloured to sit *under* the list rather than
-/// compete with it. It had a bold title and a sentence explaining both states,
-/// which gave a setting more weight than the choice it modifies — the rows above
-/// are what this screen is for, and a two-line block in ink as dark as theirs
-/// read as a third thing to decide.
-class _RememberChoice extends StatelessWidget {
-  const _RememberChoice({required this.value, required this.onChanged});
+/// The strip across the bottom: what outlives this choice, and the button that
+/// acts on it.
+class _Footer extends StatelessWidget {
+  const _Footer({
+    required this.remember,
+    required this.onRemember,
+    required this.selected,
+    required this.onEnter,
+  });
+
+  final bool remember;
+  final ValueChanged<bool> onRemember;
+  final NetworkCredential? selected;
+  final VoidCallback onEnter;
+
+  @override
+  Widget build(BuildContext context) {
+    AppTheme.watch(context);
+    return Container(
+      margin: const EdgeInsets.only(top: 12),
+      padding: const EdgeInsets.fromLTRB(26, 16, 26, 16),
+      decoration: BoxDecoration(
+        color: AppPalette.panelBg,
+        border: Border(top: BorderSide(color: AppPalette.divider)),
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: _RememberTick(value: remember, onChanged: onRemember),
+          ),
+          const SizedBox(width: 16),
+          SizedBox(
+            height: 36,
+            child: FilledButton(
+              // Dead until there is something to enter, and saying which of the
+              // two it is: "Pick a grid" is the instruction, "Start chatting"
+              // is the promise. A button that only ever said the second would
+              // be a control the reader presses and nothing happens.
+              onPressed: selected == null ? null : onEnter,
+              child: Text(selected == null ? 'Pick a grid' : 'Start chatting'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// "Always start here" — whether this answer outlives the session.
+class _RememberTick extends StatelessWidget {
+  const _RememberTick({required this.value, required this.onChanged});
 
   final bool value;
   final ValueChanged<bool> onChanged;
@@ -156,185 +212,47 @@ class _RememberChoice extends StatelessWidget {
   Widget build(BuildContext context) {
     AppTheme.watch(context);
     final theme = Theme.of(context);
-    return InkWell(
-      onTap: () => onChanged(!value),
-      borderRadius: BorderRadius.circular(AppCard.insetRadius),
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 4),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            // Scaled rather than resized: the box shrinks to the weight of the
-            // line beside it while the hit area stays the full control, so a
-            // quieter tick is not a harder one to hit (§11).
-            SizedBox(
-              width: 18,
-              height: 18,
-              child: Transform.scale(
-                scale: 0.82,
-                child: Checkbox(
-                  value: value,
-                  visualDensity: VisualDensity.compact,
-                  materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                  onChanged: (next) => onChanged(next ?? false),
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: MouseRegion(
+        cursor: SystemMouseCursors.click,
+        child: GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: () => onChanged(!value),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Container(
+                width: 17,
+                height: 17,
+                decoration: BoxDecoration(
+                  color: value ? AppPalette.accent : AppCard.base,
+                  borderRadius: BorderRadius.circular(5),
+                  border: Border.all(
+                    color: value ? AppPalette.accent : AppPalette.textFaint,
+                    width: 1.5,
+                  ),
+                ),
+                child: value
+                    ? const Icon(
+                        Icons.check_rounded,
+                        size: 12,
+                        color: Colors.white,
+                      )
+                    : null,
+              ),
+              const SizedBox(width: 9),
+              Text(
+                'Always start here',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  fontSize: 12.5,
+                  color: AppPalette.textSecondary,
                 ),
               ),
-            ),
-            const SizedBox(width: 8),
-            Text(
-              'Remember my choice',
-              style: theme.textTheme.bodySmall?.copyWith(
-                // Matched to the link it shares a row with. Not `textFaint`:
-                // a control's own label has to clear 4.5:1 on this white card,
-                // and shrinking it buys no slack there (§11).
-                fontSize: 12,
-                color: AppPalette.textSecondary,
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-/// The link half of the labels note, sized to sit in a row beside the tick.
-///
-/// It says the words themselves rather than naming what they are. "What do
-/// these labels mean?" asks the reader to know that the coloured thing on a row
-/// is called a label — interface vocabulary they have no reason to hold, and
-/// the wrong half of the sentence to spend their attention on. Quoting `Owner`
-/// and `Public` back to them points at something already on the screen.
-class _LabelsLink extends StatelessWidget {
-  const _LabelsLink({required this.onToggle});
-
-  final VoidCallback onToggle;
-
-  /// The words as the rows above spell them, read off [GridAccessTag] rather
-  /// than typed out again — a link quoting a label that has since been renamed
-  /// points at nothing, and would do it in the one sentence promising to
-  /// explain the labels.
-  static String get _names {
-    final names = GridAccessTag.values.map((tag) => tag.label).toList();
-    final head = names.sublist(0, names.length - 1).join(', ');
-    return '$head and ${names.last}';
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    AppTheme.watch(context);
-    final theme = Theme.of(context);
-    return InkWell(
-      onTap: onToggle,
-      borderRadius: BorderRadius.circular(AppCard.insetRadius),
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 4),
-        child: Text(
-          'What do $_names mean?',
-          // A step under bodySmall, matched by the tick beside it: these two
-          // annotate the list rather than belonging to it, and at the rows'
-          // own size they competed with what they annotate.
-          //
-          // No marker beside it. A chevron is how a *row* says it opens, and
-          // this is a question in accent ink — the shape a link already has.
-          // What it opened is visible directly underneath, so a mark reporting
-          // that state would be telling the reader something the panel has
-          // already told them.
-          style: theme.textTheme.bodySmall?.copyWith(
-            fontSize: 12,
-            color: AppPalette.accent,
-            fontWeight: AppFont.medium,
+            ],
           ),
         ),
       ),
-    );
-  }
-}
-
-/// What the link opens, folding in under the row the link sits in.
-class _LabelsReveal extends StatelessWidget {
-  const _LabelsReveal({required this.open});
-
-  final bool open;
-
-  @override
-  Widget build(BuildContext context) => AnimatedSize(
-    duration: AppMotion.fold,
-    curve: Curves.easeOutCubic,
-    alignment: Alignment.topCenter,
-    child: open
-        ? const Padding(
-            padding: EdgeInsets.fromLTRB(4, 10, 0, 2),
-            child: _GridLegend(),
-          )
-        : const SizedBox(width: double.infinity),
-  );
-}
-
-/// What each label on the rows above means.
-///
-/// Shows the real pills rather than naming them: the fastest answer to "what
-/// does Public mean?" is the same badge the row wears, sitting next to its
-/// sentence. Spelling the words out in prose would leave the reader to match
-/// the two up themselves.
-class _GridLegend extends StatelessWidget {
-  const _GridLegend();
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        for (final tag in GridAccessTag.values) ...[
-          _LegendRow(tag: tag),
-          if (tag != GridAccessTag.values.last) const SizedBox(height: 7),
-        ],
-      ],
-    );
-  }
-}
-
-/// One tag beside what it means.
-class _LegendRow extends StatelessWidget {
-  const _LegendRow({required this.tag});
-
-  final GridAccessTag tag;
-
-  /// Written from the reader's side — what the tag says about *them* and this
-  /// grid, not what the control plane calls the rule.
-  String get _meaning => switch (tag) {
-    GridAccessTag.public => 'Anyone can use this one.',
-    GridAccessTag.owner => 'You created it, so you decide who joins.',
-    GridAccessTag.invited => 'Someone gave you access to theirs.',
-  };
-
-  @override
-  Widget build(BuildContext context) {
-    AppTheme.watch(context);
-    final theme = Theme.of(context);
-    return Row(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        // A fixed column so the three sentences line up. The pills are three
-        // different widths, and a ragged left edge reads as three unrelated
-        // notes rather than one legend.
-        SizedBox(
-          width: 74,
-          child: Align(
-            alignment: Alignment.centerLeft,
-            child: gridPill(tag.label, gridTagColour(tag)),
-          ),
-        ),
-        const SizedBox(width: 10),
-        Expanded(
-          child: Text(
-            _meaning,
-            style: theme.textTheme.bodySmall?.copyWith(
-              color: AppPalette.textSecondary,
-            ),
-          ),
-        ),
-      ],
     );
   }
 }

--- a/lib/features/onboarding/presentation/widgets/grid_pick_list.dart
+++ b/lib/features/onboarding/presentation/widgets/grid_pick_list.dart
@@ -1,142 +1,71 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../../../infrastructure/analytics/analytics_events.dart';
-import '../../../../infrastructure/analytics/analytics_providers.dart';
 import '../../../../infrastructure/state/models/network_credential.dart';
 import '../../../../shared/theme/app_theme.dart';
-import '../../../../shared/widgets/choice_row.dart';
-import '../../../../shared/widgets/detail_widgets.dart';
-import '../../../auth/logic/session_controller.dart';
 import '../../../network/logic/grid_access_summary.dart';
-import '../../../network/logic/grid_choice.dart';
+import '../../../network/logic/grid_choice_row.dart';
+import '../../../network/logic/grid_overview_provider.dart';
 
-/// The grids this account already belongs to, as rows you press to pick one.
+/// The grids this account can enter, grouped by the reader's standing in them
+/// and pressed to select one.
 ///
-/// Picking is the whole interaction — no radio, no Continue. A second control
-/// confirming a choice the user just made is a step that only exists to be
-/// clicked, and this screen's job is to end as soon as the question is answered.
+/// It used to be a flat list of names with a coloured word on each row, and
+/// picking a row entered the grid on the spot. Two things changed. The rows are
+/// grouped, because "yours", "you're invited" and "open to anyone" is the same
+/// fact the pills carried, said once over a set instead of once per row — and a
+/// heading can be scanned past, where a pill on every line cannot. And picking
+/// now *selects*: the button in the footer is what ends the screen, so a
+/// mis-click costs nothing and the reader can compare two grids before
+/// committing to either.
 ///
-/// It is the group itself now, not the contents of one. It used to live inside a
-/// "Your grids · 1 grid on your account" row you had to open: a disclosure whose
-/// entire payload, for most accounts, was a single line — and whose summary
-/// *described* the list ("1 grid") in the space where the list would have fit.
-/// A screen asking you to choose should open showing the things to choose from.
-///
-/// Scrolls inside a fixed height rather than growing the onboarding card: an
-/// account can be on a dozen grids, and a card that runs off a small desktop
-/// window is one the user can't finish (§4).
+/// Each row says what the grid is doing right now, probed per grid. That is the
+/// difference between choosing a grid and guessing at one: an account often has
+/// several, and the only one worth entering is the one with something answering
+/// on it.
 class GridPickList extends ConsumerWidget {
-  const GridPickList({super.key, required this.remember});
+  const GridPickList({
+    super.key,
+    required this.networks,
+    required this.selected,
+    required this.onSelect,
+  });
 
-  /// Whether picking a grid here also writes it down for the next launch.
-  /// Read at the moment of the press, so the tick below the list applies to
-  /// the choice the user is making right now.
-  final bool remember;
+  /// Already filtered by the search box above, if there is one.
+  final List<NetworkCredential> networks;
 
-  /// Roughly five rows, then it scrolls. The list grows with every public
-  /// grid the account can reach, so it has to stay a list rather than become
+  /// The grid the footer's button would enter, or null before a choice.
+  final NetworkCredential? selected;
+
+  final ValueChanged<NetworkCredential> onSelect;
+
+  /// Roughly five rows, then it scrolls. The account can reach every public
+  /// grid on the control plane, so this has to stay a list rather than become
   /// the page.
-  static const double _maxHeight = 235;
+  static const double _maxHeight = 296;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     AppTheme.watch(context);
-    final networks = ref.watch(sessionProvider).networks;
-
-    // Through the gate, not straight at [SelectedNetwork]: answering the
-    // question and opening the door are one act, and the door has to stay open
-    // afterwards — the grid can go away again later without the app throwing
-    // the user back out to this screen.
-    void pick(NetworkCredential network) {
-      ref.read(analyticsProvider).gridChoice('existing');
-      ref
-          .read(gridChoiceGateProvider.notifier)
-          .choose(network, remember: remember);
-    }
-
-    return ChoiceRowGroup(
-      outlined: true,
-      children: [
-        ConstrainedBox(
-          constraints: const BoxConstraints(maxHeight: _maxHeight),
-          child: ListView.separated(
-            padding: EdgeInsets.zero,
-            shrinkWrap: true,
-            itemCount: networks.length,
-            separatorBuilder: (_, _) =>
-                Divider(height: 1, thickness: 1, color: AppPalette.divider),
-            itemBuilder: (context, index) {
-              final network = networks[index];
-              return _GridRow(network: network, onTap: () => pick(network));
-            },
-          ),
-        ),
-      ],
-    );
-  }
-}
-
-/// One grid to press: the bolt, its name, and the tag saying why you can enter
-/// it.
-///
-/// One line, unlike the create-a-grid [ChoiceRow] below it, and the difference
-/// is the point: these are *items* to scan — an account can reach many of them
-/// — while that row is an action that has to explain itself. A list reads
-/// fastest when each entry is one line and the only thing varying across them
-/// sits in the same place on every row.
-///
-/// The tag carries what a sentence under the name would have, in a quarter of
-/// the space and without a second vocabulary: a row saying "Anyone signed in to
-/// Grid" beneath a pill saying "Public" is one fact printed twice.
-class _GridRow extends StatelessWidget {
-  const _GridRow({required this.network, required this.onTap});
-
-  final NetworkCredential network;
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    AppTheme.watch(context);
-    final theme = Theme.of(context);
-    final tag = gridAccessTagFor(network);
-    return InkWell(
-      onTap: onTap,
-      // The app's row answer: an instant hover tint, no ripple — matching
-      // [ChoiceRow], which this row shares a card with.
-      splashFactory: NoSplash.splashFactory,
-      hoverColor: AppSurface.hoverFill,
-      highlightColor: Colors.transparent,
-      child: Padding(
-        padding: const EdgeInsets.fromLTRB(15, 13, 13, 13),
-        child: Row(
+    if (networks.isEmpty) return const _NoMatches();
+    return ConstrainedBox(
+      constraints: const BoxConstraints(maxHeight: _maxHeight),
+      child: SingleChildScrollView(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            SizedBox(
-              width: 20,
-              child: Center(
-                child: Icon(
-                  Icons.bolt,
-                  size: 20,
-                  color: theme.colorScheme.onSurfaceVariant,
+            for (final group in groupGrids(networks)) ...[
+              _GroupHeading(tag: group.tag, count: group.grids.length),
+              for (final network in group.grids) ...[
+                _GridRow(
+                  network: network,
+                  selected: network.networkId == selected?.networkId,
+                  onTap: () => onSelect(network),
                 ),
-              ),
-            ),
-            const SizedBox(width: 12),
-            Expanded(
-              child: Text(
-                network.name,
-                overflow: TextOverflow.ellipsis,
-                style: theme.textTheme.titleSmall,
-              ),
-            ),
-            const SizedBox(width: 10),
-            gridPill(tag.label, gridTagColour(tag)),
-            const SizedBox(width: 10),
-            Icon(
-              Icons.chevron_right_rounded,
-              size: 19,
-              color: AppPalette.textFaint,
-            ),
+                const SizedBox(height: 7),
+              ],
+              const SizedBox(height: 5),
+            ],
           ],
         ),
       ),
@@ -144,12 +73,232 @@ class _GridRow extends StatelessWidget {
   }
 }
 
-/// The tag's tint, kept in step with the grid badges everywhere else: Public is
-/// the accent it already wears on the Grids screen, Owner the teal. Invited is
-/// the quiet one on purpose — it is the ordinary case, and a list where every
-/// row shouts has nothing left to point at the one that should be noticed.
-Color gridTagColour(GridAccessTag tag) => switch (tag) {
-  GridAccessTag.public => AppPalette.accent,
-  GridAccessTag.owner => AppPalette.teal,
-  GridAccessTag.invited => AppPalette.textSecondary,
-};
+/// "YOURS · 3" over the grids it counts.
+class _GroupHeading extends StatelessWidget {
+  const _GroupHeading({required this.tag, required this.count});
+
+  final GridAccessTag tag;
+  final int count;
+
+  @override
+  Widget build(BuildContext context) {
+    AppTheme.watch(context);
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(0, 4, 0, 9),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.baseline,
+        textBaseline: TextBaseline.alphabetic,
+        children: [
+          Text(
+            tag.groupLabel,
+            style: theme.textTheme.labelSmall?.copyWith(
+              fontSize: 10.5,
+              fontWeight: FontWeight.w700,
+              letterSpacing: 0.09 * 10.5,
+              color: AppPalette.textSecondary,
+            ),
+          ),
+          const SizedBox(width: 7),
+          Text(
+            '$count',
+            style: theme.textTheme.labelSmall?.copyWith(
+              fontSize: 10.5,
+              fontWeight: AppFont.semibold,
+              color: AppPalette.textFaint,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// One grid: whether anything is answering on it, its name, what it is doing,
+/// and whether it is the one selected.
+class _GridRow extends ConsumerStatefulWidget {
+  const _GridRow({
+    required this.network,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final NetworkCredential network;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  ConsumerState<_GridRow> createState() => _GridRowState();
+}
+
+class _GridRowState extends ConsumerState<_GridRow> {
+  bool _hovered = false;
+
+  @override
+  Widget build(BuildContext context) {
+    AppTheme.watch(context);
+    final theme = Theme.of(context);
+    // Probed per grid, sharing the cache the Grids screen fills — so a row here
+    // and a bolt there can never disagree about whether a grid is up.
+    final overview = ref.watch(
+      gridOverviewForProvider(widget.network.networkId),
+    );
+    final liveness = switch (overview) {
+      AsyncData(:final value) => GridReached(
+        running: value.state?.toLowerCase() == 'running',
+        nodes: value.stats.nodes,
+        models: value.stats.models,
+      ),
+      AsyncError() => const GridUnreachable(),
+      _ => const GridChecking(),
+    };
+    final live = liveness is GridReached && liveness.running;
+    final selected = widget.selected;
+
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      onEnter: (_) => setState(() => _hovered = true),
+      onExit: (_) => setState(() => _hovered = false),
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: widget.onTap,
+        child: AnimatedContainer(
+          duration: AppMotion.hover,
+          curve: AppMotion.curve,
+          padding: const EdgeInsets.fromLTRB(14, 12, 14, 12),
+          decoration: BoxDecoration(
+            color: AppCard.base,
+            borderRadius: BorderRadius.circular(11),
+            border: Border.all(
+              color: selected
+                  ? AppPalette.accent
+                  : _hovered
+                  ? AppPalette.textFaint
+                  : AppPalette.divider,
+            ),
+            boxShadow: selected
+                ? [
+                    BoxShadow(
+                      color: AppPalette.accent.withValues(alpha: 0.14),
+                      spreadRadius: 3,
+                    ),
+                  ]
+                : null,
+          ),
+          child: Row(
+            children: [
+              // A dot, not a bolt. The bolt is the app's mark for a grid; here
+              // every row is a grid, so the only thing worth a glyph is the one
+              // fact that differs between them.
+              Container(
+                width: 9,
+                height: 9,
+                margin: const EdgeInsets.only(left: 4),
+                decoration: BoxDecoration(
+                  color: live ? AppPalette.online : AppPalette.textFaint,
+                  shape: BoxShape.circle,
+                ),
+              ),
+              const SizedBox(width: 13),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      widget.network.name,
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.textTheme.titleSmall?.copyWith(
+                        fontSize: 14,
+                        fontWeight: AppFont.semibold,
+                        letterSpacing: -0.01 * 14,
+                      ),
+                    ),
+                    const SizedBox(height: 3),
+                    Text(
+                      gridRowMeta(liveness),
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        fontSize: 12.2,
+                        color: AppPalette.textSecondary,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 13),
+              _PickMark(selected: selected),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// The mark saying which grid the footer's button would open.
+///
+/// A tick in a circle rather than a chevron: a chevron promises that pressing
+/// the row *goes* somewhere, which is what these rows used to do and no longer
+/// do. This one says "chosen", which is what the press now means.
+class _PickMark extends StatelessWidget {
+  const _PickMark({required this.selected});
+
+  final bool selected;
+
+  @override
+  Widget build(BuildContext context) {
+    AppTheme.watch(context);
+    return AnimatedContainer(
+      duration: AppMotion.hover,
+      curve: AppMotion.curve,
+      width: 20,
+      height: 20,
+      decoration: BoxDecoration(
+        color: selected ? AppPalette.accent : AppCard.base,
+        shape: BoxShape.circle,
+        border: Border.all(
+          color: selected ? AppPalette.accent : AppPalette.divider,
+          width: 1.5,
+        ),
+      ),
+      child: selected
+          ? const Icon(Icons.check_rounded, size: 13, color: Colors.white)
+          : null,
+    );
+  }
+}
+
+/// What the list shows when a search matches nothing.
+class _NoMatches extends StatelessWidget {
+  const _NoMatches();
+
+  @override
+  Widget build(BuildContext context) {
+    AppTheme.watch(context);
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(4, 18, 4, 22),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Nothing matches that name.',
+            style: theme.textTheme.bodyMedium?.copyWith(
+              fontSize: 13.5,
+              fontWeight: AppFont.semibold,
+            ),
+          ),
+          const SizedBox(height: 5),
+          Text(
+            'Check the spelling, or start a new grid below.',
+            style: theme.textTheme.bodySmall?.copyWith(
+              fontSize: 12.5,
+              height: 1.45,
+              color: AppPalette.textSecondary,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/onboarding/presentation/widgets/grid_pick_list.dart
+++ b/lib/features/onboarding/presentation/widgets/grid_pick_list.dart
@@ -152,7 +152,10 @@ class _GridRowState extends ConsumerState<_GridRow> {
       AsyncError() => const GridUnreachable(),
       _ => const GridChecking(),
     };
-    final live = liveness is GridReached && liveness.running;
+    // The same predicate the sentence under the name uses. It read `running`
+    // on its own before, which put a green dot beside a grid reporting itself
+    // up with nothing on it — the one row a reader would have picked first.
+    final live = gridIsAnswering(liveness);
     final selected = widget.selected;
 
     return MouseRegion(

--- a/lib/features/onboarding/presentation/widgets/grid_search_field.dart
+++ b/lib/features/onboarding/presentation/widgets/grid_search_field.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+
+import '../../../../shared/theme/app_theme.dart';
+
+/// The box that narrows a long grid list, with the count it has narrowed it to.
+///
+/// The count is the half that earns this control's height. A search box on its
+/// own tells you nothing until you type; "12 grids" says how much list there is
+/// before you decide whether to search it at all, and "3 of 12" afterwards says
+/// how much of it you are still looking at.
+class GridSearchField extends StatelessWidget {
+  const GridSearchField({
+    super.key,
+    required this.controller,
+    required this.countLabel,
+    required this.onChanged,
+  });
+
+  final TextEditingController controller;
+  final String countLabel;
+  final ValueChanged<String> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    AppTheme.watch(context);
+    final theme = Theme.of(context);
+    return Container(
+      height: 36,
+      padding: const EdgeInsets.symmetric(horizontal: 11),
+      decoration: BoxDecoration(
+        color: AppPalette.panelBg,
+        borderRadius: BorderRadius.circular(9),
+        border: Border.all(color: AppPalette.divider),
+      ),
+      child: Row(
+        children: [
+          Icon(Icons.search, size: 15, color: AppPalette.textSecondary),
+          const SizedBox(width: 9),
+          Expanded(
+            child: TextField(
+              controller: controller,
+              onChanged: onChanged,
+              style: theme.textTheme.bodyMedium?.copyWith(fontSize: 13.5),
+              decoration: InputDecoration(
+                isDense: true,
+                border: InputBorder.none,
+                contentPadding: EdgeInsets.zero,
+                hintText: 'Search grids',
+                hintStyle: theme.textTheme.bodyMedium?.copyWith(
+                  fontSize: 13.5,
+                  color: AppPalette.textFaint,
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(width: 9),
+          Text(
+            countLabel,
+            style: theme.textTheme.labelSmall?.copyWith(
+              fontSize: 11.5,
+              fontWeight: AppFont.semibold,
+              color: AppPalette.textSecondary,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/onboarding/presentation/widgets/new_grid_form.dart
+++ b/lib/features/onboarding/presentation/widgets/new_grid_form.dart
@@ -25,7 +25,15 @@ import '../../../network/presentation/grid_type_picker.dart';
 /// differs is only what happens after: the dialog closes and toasts, while this
 /// selects the new grid, which is what ends this screen.
 class NewGridForm extends ConsumerStatefulWidget {
-  const NewGridForm({super.key});
+  const NewGridForm({super.key, required this.open, required this.onToggle});
+
+  /// Whether the form is showing under its own header row.
+  final bool open;
+
+  /// Opens and shuts it. Owned by the screen, because opening this is also what
+  /// clears the grid selected in the list — one of the two is the answer, never
+  /// both.
+  final VoidCallback onToggle;
 
   @override
   ConsumerState<NewGridForm> createState() => _NewGridFormState();
@@ -110,12 +118,47 @@ class _NewGridFormState extends ConsumerState<NewGridForm> {
         ? _type
         : ManagedNetworkType.fallback;
 
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(15, 0, 14, 14),
+    // A dashed rim, and the one on this screen. Every other surface here is a
+    // grid that exists; this is the outline of one that doesn't yet, which is
+    // what a dashed edge has meant since long before this app.
+    return AnimatedContainer(
+      duration: AppMotion.fold,
+      curve: AppMotion.curve,
+      decoration: BoxDecoration(
+        color: AppPalette.panelBg,
+        borderRadius: BorderRadius.circular(11),
+      ),
+      foregroundDecoration: _DashedRim(
+        color: widget.open ? AppPalette.accentMuted : AppPalette.textFaint,
+        radius: 11,
+      ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          const FieldLabel('Name'),
+          _CreateHeader(open: widget.open, onTap: widget.onToggle),
+          if (widget.open)
+            _body(context, selected, submitting, error, types, domain),
+        ],
+      ),
+    );
+  }
+
+  Widget _body(
+    BuildContext context,
+    ManagedNetworkType selected,
+    bool submitting,
+    String? error,
+    List<ManagedNetworkType> types,
+    String? domain,
+  ) {
+    // Indented past the glyph above it, so the fields read as belonging to the
+    // row that revealed them rather than as a second list.
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(45, 4, 14, 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const FieldLabel('Name it'),
           TextField(
             controller: _name,
             autofocus: true,
@@ -168,5 +211,113 @@ class _NewGridFormState extends ConsumerState<NewGridForm> {
         ],
       ),
     );
+  }
+}
+
+/// The row that opens the create form: what it is, what it costs you, and a
+/// caret that turns.
+class _CreateHeader extends StatelessWidget {
+  const _CreateHeader({required this.open, required this.onTap});
+
+  final bool open;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    AppTheme.watch(context);
+    final theme = Theme.of(context);
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(15, 13, 14, 13),
+          child: Row(
+            children: [
+              Icon(Icons.add, size: 16, color: AppPalette.textSecondary),
+              const SizedBox(width: 14),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Start a new grid',
+                      style: theme.textTheme.titleSmall?.copyWith(
+                        fontSize: 14,
+                        fontWeight: AppFont.semibold,
+                        letterSpacing: -0.01 * 14,
+                      ),
+                    ),
+                    const SizedBox(height: 3),
+                    Text(
+                      'Private by default. Invite whoever you want.',
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        fontSize: 12.2,
+                        color: AppPalette.textSecondary,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 13),
+              AnimatedRotation(
+                turns: open ? 0.25 : 0,
+                duration: AppMotion.fold,
+                curve: AppMotion.curve,
+                child: Icon(
+                  Icons.chevron_right_rounded,
+                  size: 18,
+                  color: AppPalette.textSecondary,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// A dashed rounded rim, which Flutter's `Border` cannot draw.
+class _DashedRim extends Decoration {
+  const _DashedRim({required this.color, required this.radius});
+
+  final Color color;
+  final double radius;
+
+  @override
+  BoxPainter createBoxPainter([VoidCallback? onChanged]) =>
+      _DashedRimPainter(color: color, radius: radius);
+}
+
+class _DashedRimPainter extends BoxPainter {
+  _DashedRimPainter({required this.color, required this.radius});
+
+  final Color color;
+  final double radius;
+
+  @override
+  void paint(Canvas canvas, Offset offset, ImageConfiguration cfg) {
+    final size = cfg.size;
+    if (size == null) return;
+    final rect = RRect.fromRectAndRadius(
+      (offset & size).deflate(0.5),
+      Radius.circular(radius),
+    );
+    final paint = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 1
+      ..color = color;
+    // 5 on, 4 off — long enough to read as a dash at this radius, short enough
+    // that the corners still look like corners.
+    for (final metric in (Path()..addRRect(rect)).computeMetrics()) {
+      var start = 0.0;
+      while (start < metric.length) {
+        final end = (start + 5).clamp(0.0, metric.length);
+        canvas.drawPath(metric.extractPath(start, end), paint);
+        start = end + 4;
+      }
+    }
   }
 }

--- a/lib/shared/layouts/onboarding_page.dart
+++ b/lib/shared/layouts/onboarding_page.dart
@@ -28,6 +28,7 @@ class OnboardingPage extends StatelessWidget {
     this.meta,
     this.corner,
     this.leading,
+    this.footer,
   });
 
   /// A mark above the title, inside the card — the brand, on the one screen
@@ -56,6 +57,14 @@ class OnboardingPage extends StatelessWidget {
 
   final List<Widget> children;
 
+  /// A strip across the bottom of the card, edge to edge and on its own ground.
+  ///
+  /// Outside the card's padding on purpose: what goes here is the screen's
+  /// standing controls — a tick that outlives the choice, the button that ends
+  /// the screen — and a rule under a tinted strip is what separates "the thing
+  /// you are choosing" from "what happens when you have".
+  final Widget? footer;
+
   @override
   Widget build(BuildContext context) {
     AppTheme.watch(context);
@@ -82,6 +91,7 @@ class OnboardingPage extends StatelessWidget {
                       title: title,
                       subtitle: subtitle,
                       meta: meta,
+                      footer: footer,
                       children: children,
                     ),
                   ),
@@ -107,6 +117,7 @@ class _Card extends StatelessWidget {
     required this.title,
     required this.subtitle,
     required this.meta,
+    required this.footer,
     required this.children,
   });
 
@@ -114,54 +125,76 @@ class _Card extends StatelessWidget {
   final String title;
   final String? subtitle;
   final String? meta;
+  final Widget? footer;
   final List<Widget> children;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return ConstrainedBox(
-      constraints: const BoxConstraints(maxWidth: 540),
-      child: DecoratedBox(
+      // The design's card: 480 across, radius 16, and its sides padded 26. It
+      // was 540/18/32 — a frame drawn before this screen had a scrolling list
+      // and a footer in it, and roomier than either wants.
+      constraints: const BoxConstraints(maxWidth: 480),
+      child: Container(
         decoration: BoxDecoration(
           color: AppCard.base,
-          borderRadius: BorderRadius.circular(18),
+          borderRadius: BorderRadius.circular(16),
           border: Border.all(color: AppGlass.hair),
           boxShadow: AppCard.heroShadow,
         ),
-        child: Padding(
-          padding: const EdgeInsets.fromLTRB(32, 30, 32, 28),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              if (leading != null) ...[
-                Align(alignment: Alignment.centerLeft, child: leading!),
-                const SizedBox(height: 18),
-              ],
-              Text(title, style: theme.textTheme.headlineSmall),
-              if (subtitle case final subtitle?) ...[
-                const SizedBox(height: 6),
-                Row(
-                  children: [
-                    Expanded(
-                      child: Text(
-                        subtitle,
-                        style: theme.textTheme.bodyMedium?.copyWith(
-                          color: AppPalette.textSecondary,
-                        ),
-                      ),
-                    ),
-                    if (meta != null) ...[
-                      const SizedBox(width: 12),
-                      MetaLabel(meta!),
-                    ],
+        // So a footer can run to the card's own rounded edge.
+        clipBehavior: Clip.antiAlias,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Padding(
+              padding: EdgeInsets.fromLTRB(26, 26, 26, footer == null ? 26 : 6),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  if (leading != null) ...[
+                    Align(alignment: Alignment.centerLeft, child: leading!),
+                    const SizedBox(height: 18),
                   ],
-                ),
-              ],
-              const SizedBox(height: 22),
-              ...children,
-            ],
-          ),
+                  Text(
+                    title,
+                    style: theme.textTheme.titleLarge?.copyWith(
+                      fontSize: 20,
+                      fontWeight: AppFont.semibold,
+                      letterSpacing: -0.024 * 20,
+                    ),
+                  ),
+                  if (subtitle case final subtitle?) ...[
+                    const SizedBox(height: 8),
+                    Row(
+                      children: [
+                        Expanded(
+                          child: Text(
+                            subtitle,
+                            style: theme.textTheme.bodyMedium?.copyWith(
+                              fontSize: 13.5,
+                              height: 1.5,
+                              color: AppPalette.textSecondary,
+                            ),
+                          ),
+                        ),
+                        if (meta != null) ...[
+                          const SizedBox(width: 12),
+                          MetaLabel(meta!),
+                        ],
+                      ],
+                    ),
+                  ],
+                  const SizedBox(height: 16),
+                  ...children,
+                ],
+              ),
+            ),
+            ?footer,
+          ],
         ),
       ),
     );

--- a/test/network/grid_choice_row_test.dart
+++ b/test/network/grid_choice_row_test.dart
@@ -35,9 +35,9 @@ void main() {
       expect(gridRowMeta(const GridChecking()), 'Checking…');
       expect(
         gridRowMeta(const GridChecking()),
-        isNot(contains('Nobody')),
+        isNot(contains('No computers')),
         reason:
-            'every grid is unprobed for the first second, and "nobody '
+            'every grid is unprobed for the first second, and "no computers '
             'answering" there would send a reader past a working grid',
       );
     });
@@ -46,12 +46,47 @@ void main() {
       expect(
         gridRowMeta(const GridUnreachable()),
         "Can't reach this grid right now",
+        reason: 'a control plane that is down is not a grid with nobody on it',
       );
       expect(
         gridRowMeta(const GridReached(running: false, nodes: 0, models: 0)),
-        'Nobody answering right now',
-        reason: 'a control plane that is down is not a grid with nobody on it',
+        'No computers answering',
       );
+    });
+
+    test('a grid reporting itself up with nothing on it is not answering', () {
+      const empty = GridReached(running: true, nodes: 0, models: 0);
+      expect(
+        gridRowMeta(empty),
+        'No computers answering',
+        reason:
+            'two grids on a real account report running with no nodes, and '
+            'this row is what a person picks a grid on',
+      );
+      expect(gridIsAnswering(empty), isFalse);
+    });
+
+    test('the dot and the sentence never disagree', () {
+      const cases = [
+        GridChecking(),
+        GridUnreachable(),
+        GridReached(running: false, nodes: 3, models: 1),
+        GridReached(running: true, nodes: 0, models: 0),
+        GridReached(running: true, nodes: 2, models: 5),
+      ];
+      for (final liveness in cases) {
+        final idle =
+            !gridIsAnswering(liveness) &&
+            liveness is! GridChecking &&
+            liveness is! GridUnreachable;
+        expect(
+          gridRowMeta(liveness).contains('No computers answering'),
+          idle,
+          reason:
+              'the green dot and the line under it are one claim about one '
+              'grid, so they read the same predicate',
+        );
+      }
     });
 
     test('counts what is answering, and what it can answer with', () {

--- a/test/network/grid_choice_row_test.dart
+++ b/test/network/grid_choice_row_test.dart
@@ -1,0 +1,148 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:grid_app/features/network/logic/grid_access_summary.dart';
+import 'package:grid_app/features/network/logic/grid_choice_row.dart';
+import 'package:grid_app/infrastructure/state/models/network_credential.dart';
+
+/// The line under a grid's name is what somebody picks a grid *on*. Every one
+/// of its parts has a "we don't know yet" that reads as a fact if it falls
+/// through to zero — a grid still being probed would claim nobody is answering,
+/// and a reader would pass over the one grid that was working.
+
+NetworkCredential _grid(
+  String name, {
+  String networkType = 'permissioned-public',
+  List<String> roles = const ['consumer'],
+}) => NetworkCredential(
+  networkId: name,
+  name: name,
+  networkType: networkType,
+  lanSignalingUrl: 'http://127.0.0.1:8090',
+  accessToken: 'tok',
+  refreshToken: '',
+  email: 'dev@x.com',
+  nodeId: 'node-1',
+  deviceId: 'dev',
+  roles: roles,
+  scopes: const ['consumer:chat'],
+  memberEpoch: 1,
+  networkEpoch: 1,
+  expiresAt: 0,
+);
+
+void main() {
+  group('gridRowMeta', () {
+    test('an unanswered probe says so, never that the grid is empty', () {
+      expect(gridRowMeta(const GridChecking()), 'Checking…');
+      expect(
+        gridRowMeta(const GridChecking()),
+        isNot(contains('Nobody')),
+        reason:
+            'every grid is unprobed for the first second, and "nobody '
+            'answering" there would send a reader past a working grid',
+      );
+    });
+
+    test('a grid that did not answer is told apart from an idle one', () {
+      expect(
+        gridRowMeta(const GridUnreachable()),
+        "Can't reach this grid right now",
+      );
+      expect(
+        gridRowMeta(const GridReached(running: false, nodes: 0, models: 0)),
+        'Nobody answering right now',
+        reason: 'a control plane that is down is not a grid with nobody on it',
+      );
+    });
+
+    test('counts what is answering, and what it can answer with', () {
+      expect(
+        gridRowMeta(const GridReached(running: true, nodes: 4, models: 6)),
+        '4 computers answering · 6 models',
+      );
+    });
+
+    test('says one of anything in the singular', () {
+      expect(
+        gridRowMeta(const GridReached(running: true, nodes: 1, models: 1)),
+        '1 computer answering · 1 model',
+      );
+    });
+
+    test('drops the models clause rather than printing a zero', () {
+      expect(
+        gridRowMeta(const GridReached(running: true, nodes: 2, models: 0)),
+        '2 computers answering',
+        reason: '"· 0 models" reads as a fault in a grid that is answering',
+      );
+    });
+  });
+
+  group('groupGrids', () {
+    test('leads with what is yours, then invited, then open', () {
+      final grouped = groupGrids([
+        _grid('open', networkType: 'permissionless'),
+        _grid('joined'),
+        _grid('mine', roles: const ['admin']),
+      ]);
+      expect(grouped.map((g) => g.tag).toList(), [
+        GridAccessTag.owner,
+        GridAccessTag.invited,
+        GridAccessTag.public,
+      ]);
+      expect(grouped.map((g) => g.grids.single.name).toList(), [
+        'mine',
+        'joined',
+        'open',
+      ]);
+    });
+
+    test('draws no heading over an empty group', () {
+      final grouped = groupGrids([_grid('joined')]);
+      expect(grouped.length, 1);
+      expect(grouped.single.tag, GridAccessTag.invited);
+    });
+
+    test('loses no grid, whatever the mix', () {
+      final all = [
+        _grid('a', networkType: 'permissionless'),
+        _grid('b'),
+        _grid('c', roles: const ['admin']),
+        _grid('d', networkType: 'permissionless'),
+      ];
+      final grouped = groupGrids(all);
+      expect(grouped.expand((g) => g.grids).length, all.length);
+    });
+  });
+
+  group('filterGrids', () {
+    test('a blank query is not a filter', () {
+      final all = [_grid('Kelvin grid'), _grid('Water Grid')];
+      expect(filterGrids(all, '').length, 2);
+      expect(filterGrids(all, '   ').length, 2);
+    });
+
+    test('matches however the name is cased or padded', () {
+      final all = [_grid('Kelvin grid'), _grid('Water Grid')];
+      expect(filterGrids(all, '  WATER ').single.name, 'Water Grid');
+    });
+
+    test('matches inside the name, not only at the start', () {
+      expect(
+        filterGrids([_grid('Kelvin grid')], 'vin').single.name,
+        'Kelvin grid',
+      );
+    });
+  });
+
+  group('gridCountLabel', () {
+    test('names the whole list when nothing is filtered out', () {
+      expect(gridCountLabel(shown: 12, total: 12), '12 grids');
+      expect(gridCountLabel(shown: 1, total: 1), '1 grid');
+    });
+
+    test('says how much of the list is left while filtering', () {
+      expect(gridCountLabel(shown: 3, total: 12), '3 of 12');
+      expect(gridCountLabel(shown: 0, total: 12), '0 of 12');
+    });
+  });
+}


### PR DESCRIPTION
Built to the designer's Grid Picker mockup.

The screen listed grid names with a coloured word on each row, and pressing a
row entered that grid on the spot. Two things were wrong with that. The rows
said nothing about the grids — an account with three of them gave no way to tell
which had anything running — and because a press was final, there was no way to
look before leaping.

## Rows carry what the grid is doing

A dot and a live sentence, probed per grid through `gridOverviewForProvider` —
the same cache the Grids list colours its bolt from, so the two can never
disagree.

```
YOURS 2
  ●  Kelvin grid     1 computer answering · 2 models
  ○  Scholes grid    No computers answering
OPEN TO ANYONE 1
  ○  Water Grid      No computers answering
```

Every unknown says so instead of falling through to a zero: `Checking…` while
the probe is out, "Can't reach this grid right now" when it fails. A grid still
being probed that claimed nobody was answering would send a reader straight past
the one grid that was working.

**One predicate behind both marks.** `gridIsAnswering` is `running && nodes > 0`,
and the dot and the sentence both go through it. They read different fields at
first — the dot took `state: running`, the sentence took the count — and two
grids on a real account report running with no nodes, so the list put a green
dot beside the two grids that could not answer a question. There is a test that
walks every liveness a row can be in and asserts the two agree.

## Grouped, not tagged

YOURS · YOU'RE INVITED · OPEN TO ANYONE is the same fact the Public/Owner/Invited
pills carried, said once over a set instead of once per row — and a heading is
scannable where a pill on every line is noise. `GridAccessTag` keeps both forms,
so the row badge and the group heading cannot drift.

## Picking selects; the footer enters

A tick in a circle replaced the chevron, because a chevron promised the row
*went* somewhere and it no longer does. The button reads "Pick a grid" until
there is one and "Start chatting" after — a disabled control that will not say
which state it is in is one people stare at. "Remember my choice" became
"Always start here" and moved into the footer with it.

This is the change most worth a second opinion: choosing is now two presses
rather than one. It earns that only because the rows are worth comparing, which
they were not before.

## Also

- **A search box above six grids**, with the count beside it: "12 grids" before
  you type, "3 of 12" after.
- **"Start a new grid" is a dashed outline** — the one on this screen, because
  every other surface here is a grid that exists and this is the shape of one
  that doesn't yet. It opens in place onto Name it / Who can join / Create grid.
- `OnboardingPage` gained a full-bleed `footer` slot and moved to the design's
  frame (480 wide, radius 16, 26 padding, 20px title). It is the shared pre-app
  card, so **the installer and approval screens move with it** — worth a look
  from anyone who knows those two.

## Not built

"last used 2m ago" and "invited by Priya", both in the mockup. Nothing here
records when a grid was last opened or who did the inviting, and a plausible
sentence in that slot is worse than none.

## Checks

- `flutter analyze lib test` → **0 issues** (Flutter 3.44.4, the CI pin).
- **3014 tests pass, 2 fail** — both in `test/agent/claude_exec_test.dart`, and
  both fail identically on a clean `main`: `d6a185c5` commented out
  `kClaudeSessionSchedulerTools` without touching the tests that assert it.
  **`main` is red right now**, independently of this branch.
- 15 new tests in `test/network/grid_choice_row_test.dart` cover the row
  sentence, the liveness predicate, the grouping, the filter and the count. No
  widget tests (§8).
- Verified in the running app: the list, the empty-grid rows, and the create
  block opened.

## Branch name

`feat/share-intelligence-redesign` is left over from #80, which merged. Nothing
in this PR touches Share Intelligence — say the word and I'll move these two
commits onto a branch that says what they are.
